### PR TITLE
Fixes #72

### DIFF
--- a/src/services/helpers.js
+++ b/src/services/helpers.js
@@ -67,8 +67,14 @@ export function isFloat(value) {
  * @return {Number}
  */
 export function countFractionDigits(number = 0) {
-  const fractionDigits = number.toString().split('.')[1]
-  return fractionDigits ? fractionDigits.length : 0
+  const stringRepresentation = number.toString()
+  if (stringRepresentation.indexOf('e-') > 0) {
+    // It's too small for a normal string representation, e.g. 1e-7 instead of 0.00000001
+    return parseInt(stringRepresentation.split('e-')[1])
+  } else {
+    const fractionDigits = stringRepresentation.split('.')[1]
+    return fractionDigits ? fractionDigits.length : 0
+  }
 }
 
 /**

--- a/test/unit/calculator.spec.js
+++ b/test/unit/calculator.spec.js
@@ -23,6 +23,9 @@ describe('Calculator', () => {
     test('should return the product of two floats', () => {
       expect(calculator.multiply(8.52, 8.6186)).toBe(73.430472)
     })
+    test('should return the product of numbers that are in scientific notation as strings', () => {
+      expect(calculator.multiply(1, 1e-10)).toBe(1e-10)
+    })
   })
   describe('#divide', () => {
     test('should return the quotient of two numbers', () => {

--- a/test/unit/dinero.spec.js
+++ b/test/unit/dinero.spec.js
@@ -121,6 +121,20 @@ describe('Dinero', () => {
           .toObject()
       ).toThrow()
     })
+    test('should convert between precisions correctly', () => {
+      expect(
+        Dinero({ amount: 333336, precision: 5 })
+          .convertPrecision(2)
+          .toObject()
+      ).toMatchObject({ amount: 333, precision: 2 })
+    })
+    test('should convert from long initial precisions correctly', () => {
+      expect(
+        Dinero({ amount: 3333333336, precision: 9 })
+          .convertPrecision(2)
+          .toObject()
+      ).toMatchObject({ amount: 333, precision: 2 })
+    })
   })
   describe('#add', () => {
     test('should return a new Dinero object with same amount plus the amount of the other', () => {

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -70,6 +70,9 @@ describe('Helpers', () => {
     test('should return true with a string', () => {
       expect(Helpers.isFloat('5.5')).toBe(true)
     })
+    test('should return true with a number in scientific notation', () => {
+      expect(Helpers.isFloat(1e-15)).toBe(true)
+    })
     test('should return false with NaN', () => {
       expect(Helpers.isFloat(NaN)).toBe(false)
     })
@@ -86,6 +89,12 @@ describe('Helpers', () => {
     })
     test('should return 0 when no argument is passed', () => {
       expect(Helpers.countFractionDigits()).toBe(0)
+    })
+    test('should return the right amount when a number in scientific notation is passed', () => {
+      expect(Helpers.countFractionDigits(1e-7)).toBe(7)
+    })
+    test('should return the right amount when a smaller number in scientific notation is passed', () => {
+      expect(Helpers.countFractionDigits(1e-15)).toBe(15)
     })
   })
   describe('#isHalf', () => {


### PR DESCRIPTION
Fixed issue in determining fraction digits when a number's string was small enough that it resulted in scientific notation in the resulting string. Added tests to ensure this behaviour persists.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Compliance

- [x] My change isn't breaking (it doesn't cause existing functionality to change).
- [x] I have read the [CONTRIBUTING](https://github.com/sarahdayan/dinero.js/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the coding style of this project.
- [x] I have properly formatted my commit messages with [cz-cli](https://github.com/commitizen/cz-cli), or manually, following the [Angular Commit Messages Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] I have updated the documentation accordingly, or my changes doesn't require documentation changes.
- [x] I have added tests to cover my changes, or my changes doesn't require new tests.
- [x] All new and existing tests pass.
