### PR TITLE
docs(README): add react native instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ npm install @types/dinero.js --save
 
 **This is a third-party file.** Please report issues and open PRs for it on the [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) repository.
 
+### React Native
+
+Dinero uses `Number.toLocaleString`, which is by default **not** bundled with React Native (0.60+) on Android devices. For formatting and currency symbols to display properly, you need to change the preferred build flavor of JavaScriptCore in your project, by opening `./android/app/build.gradle` and changing the line `def jscFlavor = 'org.webkit:android-jsc:+'` to `def jscFlavor = 'org.webkit:android-jsc-intl:+'`.
+
 ## Quick start
 
 Dinero.js makes it easy to create, calculate and format monetary values in JavaScript. You can perform arithmetic operations, extensively parse and format them, check for a number of things to make your own development process easier and safer.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ npm install @types/dinero.js --save
 
 ### React Native
 
-Dinero uses `Number.toLocaleString`, which is by default **not** bundled with React Native (0.60+) on Android devices. For formatting and currency symbols to display properly, you need to change the preferred build flavor of JavaScriptCore in your project, by opening `./android/app/build.gradle` and changing the line `def jscFlavor = 'org.webkit:android-jsc:+'` to `def jscFlavor = 'org.webkit:android-jsc-intl:+'`.
+Dinero uses [`Number.prototype.toLocaleString`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Number/toLocaleString), which by default **isn't bundled with React Native (0.60+) on Android devices**. For formatting and currency symbols to display properly, you need to change the preferred build flavor of JavaScriptCore in your project by opening `./android/app/build.gradle` and changing the line `def jscFlavor = 'org.webkit:android-jsc:+'` to `def jscFlavor = 'org.webkit:android-jsc-intl:+'`.
 
 ## Quick start
 


### PR DESCRIPTION
Using Dinero in our React Native app, we found that no currency symbols were showing on Android. Some digging found that newer versions of react native do not come bundled with Number.toLocaleString by default on Android, but there are instructions in the default react native project build.gradle file on how to include internationalization methods in your build, which fixed the problem for us. I thought it would be nice to include this in the readme, for others such as us who were scratching our heads as to why Dinero was working on iOS but not on Android

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Compliance

<!-- Is your PR compliant with the contributing guidelines of this project? Make sure you can check all boxes: -->

- [x] My change isn't breaking (it doesn't cause existing functionality to change).
- [x] I have read the [CONTRIBUTING](https://github.com/sarahdayan/dinero.js/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the coding style of this project.
- [x] I have properly formatted my commit messages with [cz-cli](https://github.com/commitizen/cz-cli), or manually, following the [Angular Commit Messages Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] I have updated the documentation accordingly, or my changes doesn't require documentation changes.
- [x] I have added tests to cover my changes, or my changes doesn't require new tests.
- [x] All new and existing tests pass.
