### PR TITLE
docs: document double-precision floating-point format limitations

### DIFF
--- a/src/dinero.js
+++ b/src/dinero.js
@@ -19,7 +19,7 @@ const calculator = Calculator()
  *
  * A Dinero object has:
  *
- * * An `amount`, expressed in minor currency units.
+ * * An `amount`, expressed in minor currency units, as an integer.
  * * A `currency`, expressed as an {@link https://en.wikipedia.org/wiki/ISO_4217#Active_codes ISO 4217 currency code}.
  * * A `precision`, expressed as an integer, to represent the number of decimal places in the `amount`.
  *   This is helpful when you want to represent fractional minor currency units (e.g.: $10.4545).
@@ -34,12 +34,15 @@ const calculator = Calculator()
  * * **Configuration:** {@link module:Dinero~setLocale setLocale}.
  * * **Conversion & formatting:** {@link module:Dinero~toFormat toFormat}, {@link module:Dinero~toUnit toUnit}, {@link module:Dinero~toRoundedUnit toRoundedUnit}, {@link module:Dinero~toObject toObject}, {@link module:Dinero~toJSON toJSON}, {@link module:Dinero~convertPrecision convertPrecision} and {@link module:Dinero.normalizePrecision normalizePrecision}.
  *
+ * Dinero.js uses `number`s under the hood, so it's constrained by the [double-precision floating-point format](https://en.wikipedia.org/wiki/Double-precision_floating-point_format). Using values over [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Number/MAX_SAFE_INTEGER) or below [`Number.MIN_SAFE_INTEGER`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Number/MIN_SAFE_INTEGER) will yield unpredictable results.
+ * Same goes with performing calculations: once the internal `amount` value exceeds those limits, precision is no longer guaranteed.
+ *
  * @module Dinero
  * @param  {Number} [options.amount=0] - The amount in minor currency units (as an integer).
  * @param  {String} [options.currency='USD'] - An ISO 4217 currency code.
  * @param  {String} [options.precision=2] - The number of decimal places to represent.
  *
- * @throws {TypeError} If `amount` or `precision` is invalid.
+ * @throws {TypeError} If `amount` or `precision` is invalid. Integers over [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Number/MAX_SAFE_INTEGER) or below [`Number.MIN_SAFE_INTEGER`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Number/MIN_SAFE_INTEGER) are considered valid, even though they can lead to imprecise amounts.
  *
  * @return {Object}
  */


### PR DESCRIPTION
fix #84

## Types of changes

This PR documents the limitations of 64-bit floating point IEE 754 numbers.

## Compliance

- [x] My change isn't breaking (it doesn't cause existing functionality to change).
- [x] I have read the [CONTRIBUTING](https://github.com/dinerojs/dinero.js/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the coding style of this project.
- [x] I have properly formatted my commit messages with [cz-cli](https://github.com/commitizen/cz-cli), or manually, following the [Angular Commit Messages Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] I have updated the documentation accordingly (or my changes doesn't require documentation changes).
- [x] I have added tests to cover my changes (or my changes doesn't require new tests).
- [x] I [added myself as a contributor](https://github.com/dinerojs/dinero.js/blob/develop/CONTRIBUTING.md#contributors).
