### PR TITLE
docs: Update dinro-docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Dinero.js is licensed under [MIT][license].
 [caniuse:intl]: https://caniuse.com/#feat=internationalization
 [node:full-icu]: https://nodejs.org/api/intl.html#intl_embed_the_entire_icu_full_icu
 [wiki:iso-4217]: https://en.wikipedia.org/wiki/ISO_4217
-[dinero-docs]: https://sarahdayan.github.io/dinero.js/module-Dinero.html
+[dinero-docs]: https://dinerojs.com/module-dinero
 [dinero-guidelines]: https://github.com/dinerojs/dinero.js/blob/master/CONTRIBUTING.md
 [producthunt:dinerojs]: https://www.producthunt.com/posts/dinero-js
 [fowler-money]: https://martinfowler.com/eaaCatalog/money.html


### PR DESCRIPTION
## Types of changes

Documentation: Link to "full docs" returns a github.io 404
Changed to: https://dinerojs.com/module-dinero

## Compliance

- [x] My change isn't breaking (it doesn't cause existing functionality to change).
- [x] I have read the [CONTRIBUTING](https://github.com/dinerojs/dinero.js/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the coding style of this project.
- [x] I have properly formatted my commit messages with [cz-cli](https://github.com/commitizen/cz-cli), or manually, following the [Angular Commit Messages Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] I have updated the documentation accordingly (or my changes doesn't require documentation changes).
- [x] ~I have added tests to cover my changes (or my changes doesn't require new tests).~
- [x] I [added myself as a contributor](https://github.com/dinerojs/dinero.js/blob/develop/CONTRIBUTING.md#contributors).
