### PR TITLE
feat: add compare function

### DIFF
--- a/packages/core/src/api/compare.ts
+++ b/packages/core/src/api/compare.ts
@@ -1,0 +1,62 @@
+/* eslint-disable functional/no-expression-statement */
+import { UNEQUAL_CURRENCIES_MESSAGE } from '../checks';
+import { assert } from '../helpers';
+import { compare as cmp } from '../utils';
+
+import { haveSameCurrency } from './haveSameCurrency';
+import { normalizeScale } from './normalizeScale';
+
+import type { Dinero } from '../types';
+import type { Dependencies } from './types';
+
+export type CompareParams<TAmount> = readonly [
+  dineroObject: Dinero<TAmount>,
+  comparator: Dinero<TAmount>
+];
+
+export type UnsafeCompareDependencies<TAmount> = Dependencies<TAmount>;
+
+export function unsafeCompare<TAmount>({
+  calculator,
+}: UnsafeCompareDependencies<TAmount>) {
+  const compareFn = cmp(calculator);
+
+  return function compare(
+    ...[dineroObject, comparator]: CompareParams<TAmount>
+  ) {
+    const dineroObjects = [dineroObject, comparator];
+
+    const [subjectAmount, comparatorAmount] = dineroObjects.map((d) => {
+      const { amount } = d.toJSON();
+
+      return amount;
+    });
+
+    return compareFn(subjectAmount, comparatorAmount);
+  };
+}
+
+export type SafeCompareDependencies<TAmount> = Dependencies<TAmount>;
+
+export function safeCompare<TAmount>({
+  calculator,
+}: SafeCompareDependencies<TAmount>) {
+  const normalizeFn = normalizeScale({ calculator });
+  const compareFn = unsafeCompare({
+    calculator,
+  });
+
+  return function compare(
+    ...[dineroObject, comparator]: CompareParams<TAmount>
+  ) {
+    const condition = haveSameCurrency([dineroObject, comparator]);
+    assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
+
+    const [subjectAmount, comparatorAmount] = normalizeFn([
+      dineroObject,
+      comparator,
+    ]);
+
+    return compareFn(subjectAmount, comparatorAmount);
+  };
+}

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,5 +1,6 @@
 export * from './add';
 export * from './allocate';
+export * from './compare';
 export * from './convert';
 export * from './equal';
 export * from './greaterThan';

--- a/packages/core/src/utils/__tests__/compare.test.ts
+++ b/packages/core/src/utils/__tests__/compare.test.ts
@@ -5,7 +5,7 @@ import { compare } from '../compare';
 const compareFn = compare({ compare: cmp });
 
 describe('compare', () => {
-  describe('verifying it returns -1 when first operand is less than second', () => {
+  describe('inferiority', () => {
     it('returns -1 when the first number is less than the other with positive numbers', () => {
       expect(compareFn(1, 2)).toBe(-1);
     });
@@ -19,7 +19,7 @@ describe('compare', () => {
       expect(compareFn(2e5, 3e5)).toBe(-1);
     });
   });
-  describe('verifying it returns 0 when first operand is equal to the second', () => {
+  describe('equality', () => {
     it('returns 0 when the first number is equal to the other with positive numbers', () => {
       expect(compareFn(4, 4)).toBe(0);
     });
@@ -33,7 +33,7 @@ describe('compare', () => {
       expect(compareFn(3e5, 3e5)).toBe(0);
     });
   });
-  describe('verifying it returns 1 when first operand is greater than second', () => {
+  describe('superiority', () => {
     it('returns 1 when the first number is greater than the other with positive numbers', () => {
       expect(compareFn(4, 3)).toBe(1);
     });

--- a/packages/core/src/utils/__tests__/compare.test.ts
+++ b/packages/core/src/utils/__tests__/compare.test.ts
@@ -1,0 +1,50 @@
+import { compare as cmp } from '@dinero.js/calculator-number';
+
+import { compare } from '../compare';
+
+const compareFn = compare({ compare: cmp });
+
+describe('compare', () => {
+  describe('verifying it returns -1 when first operand is less than second', () => {
+    it('returns -1 when the first number is less than the other with positive numbers', () => {
+      expect(compareFn(1, 2)).toBe(-1);
+    });
+    it('returns -1 when the first number is less than the other with negative numbers', () => {
+      expect(compareFn(-3, -2)).toBe(-1);
+    });
+    it('returns -1 when the first number is less than the other with floats', () => {
+      expect(compareFn(1.2, 2.2)).toBe(-1);
+    });
+    it('returns -1 when the first number is less than the other with numbers in scientific notation', () => {
+      expect(compareFn(2e5, 3e5)).toBe(-1);
+    });
+  });
+  describe('verifying it returns 0 when first operand is equal to the second', () => {
+    it('returns 0 when the first number is equal to the other with positive numbers', () => {
+      expect(compareFn(4, 4)).toBe(0);
+    });
+    it('returns 0 when the first number is equal to the other with negative numbers', () => {
+      expect(compareFn(-2, -2)).toBe(0);
+    });
+    it('returns 0 when the first number is equal to the other with floats', () => {
+      expect(compareFn(3.2, 3.2)).toBe(0);
+    });
+    it('returns 0 when the first number is equal to the other with numbers in scientific notation', () => {
+      expect(compareFn(3e5, 3e5)).toBe(0);
+    });
+  });
+  describe('verifying it returns 1 when first operand is greater than second', () => {
+    it('returns 1 when the first number is greater than the other with positive numbers', () => {
+      expect(compareFn(4, 3)).toBe(1);
+    });
+    it('returns 1 when the first number is greater than the other with negative numbers', () => {
+      expect(compareFn(-2, -3)).toBe(1);
+    });
+    it('returns 1 when the first number is greater than the other with floats', () => {
+      expect(compareFn(3.2, 2.2)).toBe(1);
+    });
+    it('returns 1 when the first number is greater than the other with numbers in scientific notation', () => {
+      expect(compareFn(3e5, 2e5)).toBe(1);
+    });
+  });
+});

--- a/packages/core/src/utils/compare.ts
+++ b/packages/core/src/utils/compare.ts
@@ -1,0 +1,16 @@
+import type { Calculator } from '../types';
+
+type ComparisonCalculator<TAmount> = Pick<Calculator<TAmount>, 'compare'>;
+
+/**
+ * Returns a compare function.
+ *
+ * @param calculator - The calculator to use.
+ *
+ * @returns The compare function.
+ */
+export function compare<TAmount>(calculator: ComparisonCalculator<TAmount>) {
+  return (subject: TAmount, comparator: TAmount) => {
+    return calculator.compare(subject, comparator);
+  };
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './compare';
 export * from './countTrailingZeros';
 export * from './distribute';
 export * from './equal';

--- a/packages/dinero.js/src/api/__tests__/compare.test.ts
+++ b/packages/dinero.js/src/api/__tests__/compare.test.ts
@@ -1,0 +1,40 @@
+import { EUR, USD } from '@dinero.js/currencies';
+
+import { dinero, compare } from '../../..';
+
+describe('compare', () => {
+  it('returns -1 when the first amount is less than the other', () => {
+    const d1 = dinero({ amount: 500, currency: USD });
+    const d2 = dinero({ amount: 800, currency: USD });
+
+    expect(compare(d1, d2)).toBe(-1);
+  });
+  it('returns 0 when amounts are equal', () => {
+    const d1 = dinero({ amount: 500, currency: USD });
+    const d2 = dinero({ amount: 500, currency: USD });
+
+    expect(compare(d1, d2)).toBe(0);
+  });
+  it('returns 1 when the first amount is greater than the other', () => {
+    const d1 = dinero({ amount: 800, currency: USD });
+    const d2 = dinero({ amount: 500, currency: USD });
+
+    expect(compare(d1, d2)).toBe(1);
+  });
+  it('normalizes the result to the highest scale', () => {
+    const d1 = dinero({ amount: 5000, currency: USD, scale: 3 });
+    const d2 = dinero({ amount: 800, currency: USD });
+
+    expect(compare(d1, d2)).toBe(-1);
+  });
+  it('throws when using different currencies', () => {
+    const d1 = dinero({ amount: 800, currency: USD });
+    const d2 = dinero({ amount: 500, currency: EUR });
+
+    expect(() => {
+      compare(d1, d2);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"[Dinero.js] Objects must have the same currency."`
+    );
+  });
+});

--- a/packages/dinero.js/src/api/compare.ts
+++ b/packages/dinero.js/src/api/compare.ts
@@ -1,0 +1,22 @@
+import { safeCompare } from '@dinero.js/core';
+
+import type { CompareParams } from '@dinero.js/core';
+
+/**
+ * Compares the value of a Dinero object relative to another.
+ *
+ * @param dineroObject - The Dinero object to compare.
+ * @param comparator - The Dinero object to compare to.
+ *
+ * @returns A negative number if the Dinero to compare is than the other;
+ *          0 if they are equal;
+ *          or a positive number if it is greater.
+ */
+export function compare<TAmount>(
+  ...[dineroObject, comparator]: CompareParams<TAmount>
+) {
+  const { calculator } = dineroObject;
+  const compareFn = safeCompare({ calculator });
+
+  return compareFn(dineroObject, comparator);
+}

--- a/packages/dinero.js/src/api/compare.ts
+++ b/packages/dinero.js/src/api/compare.ts
@@ -3,14 +3,12 @@ import { safeCompare } from '@dinero.js/core';
 import type { CompareParams } from '@dinero.js/core';
 
 /**
- * Compares the value of a Dinero object relative to another.
+ * Compare the value of a Dinero object relative to another.
  *
  * @param dineroObject - The Dinero object to compare.
  * @param comparator - The Dinero object to compare to.
  *
- * @returns A negative number if the Dinero to compare is than the other;
- *          0 if they are equal;
- *          or a positive number if it is greater.
+ * @returns One of -1, 0, or 1 depending on whether the first Dinero object is less than, equal to, or greater than the other.
  */
 export function compare<TAmount>(
   ...[dineroObject, comparator]: CompareParams<TAmount>

--- a/packages/dinero.js/src/api/index.ts
+++ b/packages/dinero.js/src/api/index.ts
@@ -1,5 +1,6 @@
 export * from './add';
 export * from './allocate';
+export * from './compare';
 export * from './convert';
 export * from './equal';
 export * from './greaterThan';

--- a/website/data/docs/api/comparisons/compare.mdx
+++ b/website/data/docs/api/comparisons/compare.mdx
@@ -62,9 +62,9 @@ const d4 = dinero({ amount: 500, currency: USD });
 compare(d3, d4); // 0
 ```
 
-### Sort arrays of Dinero objects
+### Sort arrays of objects
 
-One of the main use cases of the `compare` function is to enable sorting arrays of Dinero objects either from low to high (default) or high to low.
+One of the main use cases of the `compare` function is to sort Dinero objects. For example, you can use it with [`Array.prototype.sort`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
 
 ```js
 import { dinero, compare } from 'dinero.js';
@@ -74,9 +74,6 @@ const d1 = dinero({ amount: 900, currency: USD });
 const d2 = dinero({ amount: 500, currency: USD });
 const d3 = dinero({ amount: 800, currency: USD });
 
-const valuesLowToHigh = [d1, d2, d3].sort(compare);
-// [D500, D800, D900]
-
-const valuesHighToLow = [d1, d2, d3].sort((item1, item2) => -compare(item1, item2));
-// [D900, D800, D500]
+const lowToHigh = [d1, d2, d3].sort(compare);
+const highToLow = [d1, d2, d3].sort((a, b) => compare(b, a));
 ```

--- a/website/data/docs/api/comparisons/compare.mdx
+++ b/website/data/docs/api/comparisons/compare.mdx
@@ -1,0 +1,60 @@
+---
+title: compare
+description: Compares the value of a Dinero object relative to another.
+returns: number
+---
+
+Compares the value of a Dinero object relative to another; useful for sorting Dinero objects.
+
+Returns a negative number if the Dinero object is less than the other; 0 if they are equal; or a positive number if greater than the other.
+
+**You can only compare objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before comparing them.
+
+## Parameters
+
+<Parameters>
+
+<Parameter name="dineroObject" type="Dinero<TAmount>" required={true}>
+
+The first Dinero object to compare.
+
+</Parameter>
+
+<Parameter name="comparator" type="Dinero<TAmount>" required={true}>
+
+The second Dinero object to compare.
+
+</Parameter>
+
+</Parameters>
+
+## Code examples
+
+### Compare two objects
+
+```js
+import { dinero, compare } from 'dinero.js';
+import { USD } from '@dinero.js/currencies';
+
+const d1 = dinero({ amount: 800, currency: USD });
+const d2 = dinero({ amount: 500, currency: USD });
+
+compare(d1, d2); // 1
+```
+
+### Compare two objects after normalization
+
+```js
+import { dinero, compare } from 'dinero.js';
+import { USD } from '@dinero.js/currencies';
+
+const d1 = dinero({ amount: 5000, currency: USD, scale: 3 });
+const d2 = dinero({ amount: 800, currency: USD });
+
+compare(d1, d2); // -1
+
+const d3 = dinero({ amount: 5000, currency: USD, scale: 3 });
+const d4 = dinero({ amount: 500, currency: USD });
+
+compare(d3, d4); // 0
+```

--- a/website/data/docs/api/comparisons/compare.mdx
+++ b/website/data/docs/api/comparisons/compare.mdx
@@ -61,3 +61,22 @@ const d4 = dinero({ amount: 500, currency: USD });
 
 compare(d3, d4); // 0
 ```
+
+### Sort arrays of Dinero objects
+
+One of the main use cases of the `compare` function is to enable sorting arrays of Dinero objects either from low to high (default) or high to low.
+
+```js
+import { dinero, compare } from 'dinero.js';
+import { USD } from '@dinero.js/currencies';
+
+const d1 = dinero({ amount: 900, currency: USD });
+const d2 = dinero({ amount: 500, currency: USD });
+const d3 = dinero({ amount: 800, currency: USD });
+
+const valuesLowToHigh = [d1, d2, d3].sort(compare);
+// [D500, D800, D900]
+
+const valuesHighToLow = [d1, d2, d3].sort((item1, item2) => -compare(item1, item2));
+// [D900, D800, D500]
+```

--- a/website/data/docs/api/comparisons/compare.mdx
+++ b/website/data/docs/api/comparisons/compare.mdx
@@ -1,12 +1,15 @@
 ---
 title: compare
-description: Compares the value of a Dinero object relative to another.
+description: Compare the value of a Dinero object relative to another.
 returns: number
 ---
 
-Compares the value of a Dinero object relative to another; useful for sorting Dinero objects.
+Compare the value of a Dinero object relative to another. This is useful for sorting Dinero objects.
 
-Returns a negative number if the Dinero object is less than the other; 0 if they are equal; or a positive number if greater than the other.
+Possible return values are:
+- `-1` if the first Dinero object is less than the other
+- `1` if the first Dinero object is greater than the other
+- `0` if both objects are equal
 
 **You can only compare objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before comparing them.
 

--- a/website/data/sidebar.ts
+++ b/website/data/sidebar.ts
@@ -31,6 +31,7 @@ tree.add(Resource.create({ label: 'Transform scale', path: '/docs/api/conversion
 tree.add(Resource.create({ label: 'Trim scale', path: '/docs/api/conversions/trim-scale' }));
 tree.add(Resource.create({ label: 'Comparisons', path: '/docs/api/comparisons' }));
 tree.add(Resource.create({ label: 'Equal', path: '/docs/api/comparisons/equal' }));
+tree.add(Resource.create({ label: 'Compare', path: '/docs/api/comparisons/compare' }));
 tree.add(Resource.create({ label: 'Greater than', path: '/docs/api/comparisons/greater-than' }));
 tree.add(Resource.create({ label: 'Greater than or equal', path: '/docs/api/comparisons/greater-than-or-equal' }));
 tree.add(Resource.create({ label: 'Less than', path: '/docs/api/comparisons/less-than' }));


### PR DESCRIPTION
First up - great library - v2 came along at just the right moment as we were starting to look for a good Money TS solution this week. So thank you!

This PR adds another comparison function - `compare` - to simplify sorting arrays or other collections of Dinero objects.

I did my best to implement this according to existing conventions, but I'm still new to the library, so if you're happy with the intent of this PR but need changes made, please list them all and I'll update the PR. Alternatively feel free to merge and then fix it all!

I gave an attempt at also adding docs for it - as your docs are great - but almost certainly didn't do it right, but I at least wanted to try. Again feel free to send me a list of changes to make, or merge and take care of it yourself if easier.

Finally if this PR is unnecessary due to my ignorance, please let me know. I basically want a simple way to pass a function into `Array.prototype.sort()` and it seemed sensible to me to provide that in the library rather than create a separate utility function.

PS - The functionality this PR uses is existing `Calculator` functionality, since it already had a `compare` function that acted as required - so it just needed the wrapper functions to expose it (which I based off of the existing `lessThan` comparison function), and now I can sort arrays of `Dinero` objects like:

```ts
import { compare } from 'dinero.js';

const pricesLowToHigh = prices.sort((price1, price2) => compare(price1, price2));
```