### PR TITLE
fix(docs): correct typo & update code snippet

### DIFF
--- a/website/data/docs/core-concepts/mutations.mdx
+++ b/website/data/docs/core-concepts/mutations.mdx
@@ -39,7 +39,7 @@ const subtotal = products.reduce(
   dinero({ amount: 0, currency: USD })
 );
 
-const [discount] = allocate([20, 80]);
+const [discount] = allocate(subtotal,[20, 80]);
 const discounted = subtract(subtotal, discount);
 
 const shipping = dinero({ amount: 1000, currency: USD });

--- a/website/data/docs/core-concepts/mutations.mdx
+++ b/website/data/docs/core-concepts/mutations.mdx
@@ -39,7 +39,7 @@ const subtotal = products.reduce(
   dinero({ amount: 0, currency: USD })
 );
 
-const [discount] = allocate(subtotal,[20, 80]);
+const [discount] = allocate(subtotal, [20, 80]);
 const discounted = subtract(subtotal, discount);
 
 const shipping = dinero({ amount: 1000, currency: USD });

--- a/website/data/docs/core-concepts/scale.mdx
+++ b/website/data/docs/core-concepts/scale.mdx
@@ -122,7 +122,7 @@ import { dinero, add, trimScale } from 'dinero.js';
 import { USD } from '@dinero.js/currencies';
 
 const d1 = dinero({ amount: 100, currency: USD });
-const d1 = dinero({ amount: 2000000, currency: USD, scale: 6 });
+const d2 = dinero({ amount: 2000000, currency: USD, scale: 6 });
 
 const d3 = add(d1, d2); // a Dinero object with amount 3000000 and scale 6
 


### PR DESCRIPTION
Noticed a  typo in docs  @  <a href="https://v2.dinerojs.com/docs/core-concepts/scale#:~:text=100%2C%20currency%3A%20USD%20%7D)%3B-,const%20d1,-%3D%20dinero(%7B%20amount%3A%202000000">Core concepts | Scale</a>

Also the  usage of v1 api for `allocate` @  <a target="_blank" href="https://v2.dinerojs.com/docs/core-concepts/mutations#:~:text=USD%20%7D)%0A)%3B%0A%0Aconst%20%5Bdiscount%5D%20%3D-,allocate,-(%5B20%2C%2080%5D)%3B%0Aconst">Core concepts | Mutations</a>