### PR TITLE
docs: fixes example of calculating with scale

### DIFF
--- a/website/data/docs/core-concepts/scale.mdx
+++ b/website/data/docs/core-concepts/scale.mdx
@@ -88,7 +88,7 @@ const d2 = dinero({ amount: 104545, currency: USD, scale: 4 });
 
 add(d1, d2); // a Dinero object with amount 144545 and scale 4
 
-subtract(d2, d1); // a Dinero object with amount 104145 and scale 4
+subtract(d2, d1); // a Dinero object with amount 64545 and scale 4
 ```
 
 You might also need to use fractional values. For example, you may need to calculate 19.6% of a total cart, or convert a Dinero object to another currency with a 0.82 conversion rate.


### PR DESCRIPTION
Thank you for this library.

I believe there is an error in the docs in the example of calculating objects of different scales. I have validated this by running the code shown in the example and do indeed get a different result than what is shown there.