### PR TITLE
build: add TypeScript project references

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -77,7 +77,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/tsconfig.json"
      */
-    "tsconfigFilePath": "<projectFolder>/tsconfig.declaration.json"
+    "tsconfigFilePath": "<projectFolder>/tsconfig.json"
     /**
      * Provides a compiler configuration that will be used instead of reading the tsconfig.json file from disk.
      * The object must conform to the TypeScript tsconfig schema:

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -77,7 +77,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/tsconfig.json"
      */
-    "tsconfigFilePath": "<projectFolder>/tsconfig.json"
+    "tsconfigFilePath": "<projectFolder>/tsconfig.declaration.json"
     /**
      * Provides a compiler configuration that will be used instead of reading the tsconfig.json file from disk.
      * The object must conform to the TypeScript tsconfig schema:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,6 +14,7 @@ export default {
     __TEST__: true,
   },
   moduleNameMapper: {
+    '^@dinero.js/test$': '<rootDir>/test/utils/',
     '^@dinero.js/(.*)$': '<rootDir>/packages/$1/src/',
     '^dinero.js$': '<rootDir>/packages/dinero.js/src/',
   },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,7 @@ export default {
     __TEST__: true,
   },
   moduleNameMapper: {
-    '^@dinero.js/test$': '<rootDir>/test/utils/',
+    '^test-utils$': '<rootDir>/test/utils/',
     '^@dinero.js/(.*)$': '<rootDir>/packages/$1/src/',
     '^dinero.js$': '<rootDir>/packages/dinero.js/src/',
   },

--- a/packages/calculator-bigint/package.json
+++ b/packages/calculator-bigint/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
-    "build:tsc": "tsc -p ./tsconfig.declaration.json",
+    "build:tsc": "tsc -b",
     "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",

--- a/packages/calculator-bigint/tsconfig.declaration.json
+++ b/packages/calculator-bigint/tsconfig.declaration.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.declaration",
-  "compilerOptions": {
-    "outDir": "lib"
-  },
-  "include": ["src"]
-}

--- a/packages/calculator-bigint/tsconfig.declaration.json
+++ b/packages/calculator-bigint/tsconfig.declaration.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "paths": {}
+  },
+}

--- a/packages/calculator-bigint/tsconfig.declaration.json
+++ b/packages/calculator-bigint/tsconfig.declaration.json
@@ -2,5 +2,5 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "paths": {}
-  },
+  }
 }

--- a/packages/calculator-bigint/tsconfig.json
+++ b/packages/calculator-bigint/tsconfig.json
@@ -6,8 +6,6 @@
     "composite": true,
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
-  "references": [
-    { "path": "../core" },
-  ],
+  "references": [{ "path": "../core" }],
   "include": ["src"]
 }

--- a/packages/calculator-bigint/tsconfig.json
+++ b/packages/calculator-bigint/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.declaration",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "composite": true,
+    "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
+  },
+  "references": [
+    { "path": "../core" },
+  ],
+  "include": ["src"]
+}

--- a/packages/calculator-number/package.json
+++ b/packages/calculator-number/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
-    "build:tsc": "tsc -p ./tsconfig.declaration.json",
+    "build:tsc": "tsc -b",
     "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",

--- a/packages/calculator-number/tsconfig.declaration.json
+++ b/packages/calculator-number/tsconfig.declaration.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.declaration",
-  "compilerOptions": {
-    "outDir": "lib"
-  },
-  "include": ["src"]
-}

--- a/packages/calculator-number/tsconfig.declaration.json
+++ b/packages/calculator-number/tsconfig.declaration.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "paths": {}
+  },
+}

--- a/packages/calculator-number/tsconfig.declaration.json
+++ b/packages/calculator-number/tsconfig.declaration.json
@@ -2,5 +2,5 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "paths": {}
-  },
+  }
 }

--- a/packages/calculator-number/tsconfig.json
+++ b/packages/calculator-number/tsconfig.json
@@ -6,8 +6,6 @@
     "composite": true,
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
-  "references": [
-    { "path": "../core" },
-  ],
+  "references": [{ "path": "../core" }],
   "include": ["src"]
 }

--- a/packages/calculator-number/tsconfig.json
+++ b/packages/calculator-number/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.declaration",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "composite": true,
+    "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
+  },
+  "references": [
+    { "path": "../core" },
+  ],
+  "include": ["src"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
-    "build:tsc": "tsc -p ./tsconfig.declaration.json",
+    "build:tsc": "tsc -b",
     "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",

--- a/packages/core/tsconfig.declaration.json
+++ b/packages/core/tsconfig.declaration.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.declaration",
-  "compilerOptions": {
-    "outDir": "lib"
-  },
-  "include": ["src"]
-}

--- a/packages/core/tsconfig.declaration.json
+++ b/packages/core/tsconfig.declaration.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "paths": {}
+  },
+}

--- a/packages/core/tsconfig.declaration.json
+++ b/packages/core/tsconfig.declaration.json
@@ -2,5 +2,5 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "paths": {}
-  },
+  }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.declaration",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "composite": true,
+    "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
+  },
+  "references": [{ "path": "../currencies" }],
+  "include": ["src"]
+}

--- a/packages/currencies/package.json
+++ b/packages/currencies/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
-    "build:tsc": "tsc -p ./tsconfig.declaration.json",
+    "build:tsc": "tsc -b",
     "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",

--- a/packages/currencies/tsconfig.declaration.json
+++ b/packages/currencies/tsconfig.declaration.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.declaration",
-  "compilerOptions": {
-    "outDir": "lib"
-  },
-  "include": ["src"]
-}

--- a/packages/currencies/tsconfig.declaration.json
+++ b/packages/currencies/tsconfig.declaration.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "paths": {}
+  },
+}

--- a/packages/currencies/tsconfig.declaration.json
+++ b/packages/currencies/tsconfig.declaration.json
@@ -2,5 +2,5 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "paths": {}
-  },
+  }
 }

--- a/packages/currencies/tsconfig.json
+++ b/packages/currencies/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.declaration",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "composite": true,
+    "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/dinero.js/package.json
+++ b/packages/dinero.js/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
-    "build:tsc": "tsc -p ./tsconfig.declaration.json",
+    "build:tsc": "tsc -b",
     "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",

--- a/packages/dinero.js/src/api/__tests__/add.test.ts
+++ b/packages/dinero.js/src/api/__tests__/add.test.ts
@@ -1,12 +1,12 @@
 import { EUR, USD, MGA, MRU } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { add, toSnapshot } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/add.test.ts
+++ b/packages/dinero.js/src/api/__tests__/add.test.ts
@@ -1,14 +1,14 @@
 import { EUR, USD, MGA, MRU } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { add, toSnapshot } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { add, toSnapshot } from '..';
 
 describe('add', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/allocate.test.ts
+++ b/packages/dinero.js/src/api/__tests__/allocate.test.ts
@@ -1,14 +1,14 @@
 import { USD, MGA } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { allocate, toSnapshot } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { allocate, toSnapshot } from '..';
 
 describe('allocate', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/allocate.test.ts
+++ b/packages/dinero.js/src/api/__tests__/allocate.test.ts
@@ -1,12 +1,12 @@
 import { USD, MGA } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { allocate, toSnapshot } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/compare.test.ts
+++ b/packages/dinero.js/src/api/__tests__/compare.test.ts
@@ -1,12 +1,12 @@
 import { EUR, USD, MGA } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { compare } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/compare.test.ts
+++ b/packages/dinero.js/src/api/__tests__/compare.test.ts
@@ -1,14 +1,14 @@
 import { EUR, USD, MGA } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { compare } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { compare } from '..';
 
 describe('compare', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/convert.test.ts
+++ b/packages/dinero.js/src/api/__tests__/convert.test.ts
@@ -1,14 +1,14 @@
 import { EUR, IQD, USD, MGA, MRU } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { convert, toSnapshot } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { convert, toSnapshot } from '..';
 
 describe('convert', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/convert.test.ts
+++ b/packages/dinero.js/src/api/__tests__/convert.test.ts
@@ -1,12 +1,12 @@
 import { EUR, IQD, USD, MGA, MRU } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { convert, toSnapshot } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/equal.test.ts
+++ b/packages/dinero.js/src/api/__tests__/equal.test.ts
@@ -1,12 +1,12 @@
 import { EUR, MGA, USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { equal } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/equal.test.ts
+++ b/packages/dinero.js/src/api/__tests__/equal.test.ts
@@ -1,14 +1,14 @@
 import { EUR, MGA, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { equal } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { equal } from '..';
 
 describe('equal', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/greaterThan.test.ts
+++ b/packages/dinero.js/src/api/__tests__/greaterThan.test.ts
@@ -1,14 +1,14 @@
 import { EUR, MGA, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { greaterThan } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { greaterThan } from '..';
 
 describe('greaterThan', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/greaterThan.test.ts
+++ b/packages/dinero.js/src/api/__tests__/greaterThan.test.ts
@@ -1,12 +1,12 @@
 import { EUR, MGA, USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { greaterThan } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/greaterThanOrEqual.test.ts
+++ b/packages/dinero.js/src/api/__tests__/greaterThanOrEqual.test.ts
@@ -1,12 +1,12 @@
 import { EUR, USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { greaterThanOrEqual } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/greaterThanOrEqual.test.ts
+++ b/packages/dinero.js/src/api/__tests__/greaterThanOrEqual.test.ts
@@ -1,14 +1,14 @@
 import { EUR, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { greaterThanOrEqual } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { greaterThanOrEqual } from '..';
 
 describe('greaterThanOrEqual', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/hasSubUnits.test.ts
+++ b/packages/dinero.js/src/api/__tests__/hasSubUnits.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { hasSubUnits } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/hasSubUnits.test.ts
+++ b/packages/dinero.js/src/api/__tests__/hasSubUnits.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { hasSubUnits } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { hasSubUnits } from '..';
 
 describe('hasSubUnits', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/haveSameAmount.test.ts
+++ b/packages/dinero.js/src/api/__tests__/haveSameAmount.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { haveSameAmount } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { haveSameAmount } from '..';
 
 describe('haveSameAmount', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/haveSameAmount.test.ts
+++ b/packages/dinero.js/src/api/__tests__/haveSameAmount.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { haveSameAmount } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/haveSameCurrency.test.ts
+++ b/packages/dinero.js/src/api/__tests__/haveSameCurrency.test.ts
@@ -1,14 +1,14 @@
 import { EUR, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { haveSameCurrency } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { haveSameCurrency } from '..';
 
 describe('haveSameCurrency', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/haveSameCurrency.test.ts
+++ b/packages/dinero.js/src/api/__tests__/haveSameCurrency.test.ts
@@ -1,12 +1,12 @@
 import { EUR, USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { haveSameCurrency } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/isNegative.test.ts
+++ b/packages/dinero.js/src/api/__tests__/isNegative.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { isNegative } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/isNegative.test.ts
+++ b/packages/dinero.js/src/api/__tests__/isNegative.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { isNegative } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { isNegative } from '..';
 
 describe('isNegative', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/isPositive.test.ts
+++ b/packages/dinero.js/src/api/__tests__/isPositive.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { isPositive } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/isPositive.test.ts
+++ b/packages/dinero.js/src/api/__tests__/isPositive.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { isPositive } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { isPositive } from '..';
 
 describe('isPositive', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/isZero.test.ts
+++ b/packages/dinero.js/src/api/__tests__/isZero.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { isZero } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { isZero } from '..';
 
 describe('isZero', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/isZero.test.ts
+++ b/packages/dinero.js/src/api/__tests__/isZero.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { isZero } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/lessThan.test.ts
+++ b/packages/dinero.js/src/api/__tests__/lessThan.test.ts
@@ -1,14 +1,14 @@
 import { EUR, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { lessThan } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { lessThan } from '..';
 
 describe('lessThan', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/lessThan.test.ts
+++ b/packages/dinero.js/src/api/__tests__/lessThan.test.ts
@@ -1,12 +1,12 @@
 import { EUR, USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { lessThan } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/lessThanOrEqual.test.ts
+++ b/packages/dinero.js/src/api/__tests__/lessThanOrEqual.test.ts
@@ -1,14 +1,14 @@
 import { EUR, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { lessThanOrEqual } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { lessThanOrEqual } from '..';
 
 describe('lessThanOrEqual', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/lessThanOrEqual.test.ts
+++ b/packages/dinero.js/src/api/__tests__/lessThanOrEqual.test.ts
@@ -1,12 +1,12 @@
 import { EUR, USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { lessThanOrEqual } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/maximum.test.ts
+++ b/packages/dinero.js/src/api/__tests__/maximum.test.ts
@@ -1,12 +1,12 @@
 import { EUR, USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { maximum, toSnapshot } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/maximum.test.ts
+++ b/packages/dinero.js/src/api/__tests__/maximum.test.ts
@@ -1,14 +1,14 @@
 import { EUR, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { maximum, toSnapshot } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { maximum, toSnapshot } from '..';
 
 describe('maximum', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/minimum.test.ts
+++ b/packages/dinero.js/src/api/__tests__/minimum.test.ts
@@ -1,14 +1,14 @@
 import { EUR, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { minimum, toSnapshot } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { minimum, toSnapshot } from '..';
 
 describe('minimum', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/minimum.test.ts
+++ b/packages/dinero.js/src/api/__tests__/minimum.test.ts
@@ -1,12 +1,12 @@
 import { EUR, USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { minimum, toSnapshot } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/multiply.test.ts
+++ b/packages/dinero.js/src/api/__tests__/multiply.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { multiply, toSnapshot } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/multiply.test.ts
+++ b/packages/dinero.js/src/api/__tests__/multiply.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { multiply, toSnapshot } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { multiply, toSnapshot } from '..';
 
 describe('multiply', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/normalizeScale.test.ts
+++ b/packages/dinero.js/src/api/__tests__/normalizeScale.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { normalizeScale, toSnapshot } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/normalizeScale.test.ts
+++ b/packages/dinero.js/src/api/__tests__/normalizeScale.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { normalizeScale, toSnapshot } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { normalizeScale, toSnapshot } from '..';
 
 describe('normalizeScale', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/subtract.test.ts
+++ b/packages/dinero.js/src/api/__tests__/subtract.test.ts
@@ -1,14 +1,14 @@
 import { EUR, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { subtract, toSnapshot } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { subtract, toSnapshot } from '..';
 
 describe('subtract', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/subtract.test.ts
+++ b/packages/dinero.js/src/api/__tests__/subtract.test.ts
@@ -1,12 +1,12 @@
 import { EUR, USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { subtract, toSnapshot } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/toFormat.test.ts
+++ b/packages/dinero.js/src/api/__tests__/toFormat.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { toFormat } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { toFormat } from '..';
 
 describe('toFormat', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/toFormat.test.ts
+++ b/packages/dinero.js/src/api/__tests__/toFormat.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { toFormat } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/toSnapshot.test.ts
+++ b/packages/dinero.js/src/api/__tests__/toSnapshot.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { toSnapshot } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { toSnapshot } from '..';
 
 describe('toSnapshot', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/toSnapshot.test.ts
+++ b/packages/dinero.js/src/api/__tests__/toSnapshot.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { toSnapshot } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/transformScale.test.ts
+++ b/packages/dinero.js/src/api/__tests__/transformScale.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { toSnapshot, transformScale } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/transformScale.test.ts
+++ b/packages/dinero.js/src/api/__tests__/transformScale.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { toSnapshot, transformScale } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { toSnapshot, transformScale } from '..';
 
 describe('transformScale', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/trimScale.test.ts
+++ b/packages/dinero.js/src/api/__tests__/trimScale.test.ts
@@ -1,14 +1,14 @@
 import { USD } from '@dinero.js/currencies';
-import Big from 'big.js';
-
-import { toSnapshot, trimScale } from '..';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '../../../../../test/utils';
+} from '@dinero.js/test';
+import Big from 'big.js';
+
+import { toSnapshot, trimScale } from '..';
 
 describe('trimScale', () => {
   describe('number', () => {

--- a/packages/dinero.js/src/api/__tests__/trimScale.test.ts
+++ b/packages/dinero.js/src/api/__tests__/trimScale.test.ts
@@ -1,12 +1,12 @@
 import { USD } from '@dinero.js/currencies';
+import Big from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
   createNumberDinero,
   createBigintDinero,
   createBigjsDinero,
-} from '@dinero.js/test';
-import Big from 'big.js';
+} from 'test-utils';
 
 import { toSnapshot, trimScale } from '..';
 

--- a/packages/dinero.js/src/api/__tests__/tsconfig.json
+++ b/packages/dinero.js/src/api/__tests__/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig",
+  "references": [
+    { "path": "../../../../core" },
+    { "path": "../../../../currencies" },
+    { "path": "../../../../../test" }
+  ],
+  "exclude": []
+}

--- a/packages/dinero.js/tsconfig.declaration.json
+++ b/packages/dinero.js/tsconfig.declaration.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.declaration",
-  "compilerOptions": {
-    "outDir": "lib"
-  },
-  "include": ["src"]
-}

--- a/packages/dinero.js/tsconfig.declaration.json
+++ b/packages/dinero.js/tsconfig.declaration.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "paths": {}
+  },
+}

--- a/packages/dinero.js/tsconfig.declaration.json
+++ b/packages/dinero.js/tsconfig.declaration.json
@@ -2,5 +2,5 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "paths": {}
-  },
+  }
 }

--- a/packages/dinero.js/tsconfig.json
+++ b/packages/dinero.js/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
+    "composite": true,
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "references": [

--- a/packages/dinero.js/tsconfig.json
+++ b/packages/dinero.js/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.declaration",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
+  },
+  "references": [
+    { "path": "../calculator-number" },
+    { "path": "../core" },
+    { "path": "../currencies" }
+  ],
+  "include": ["src"]
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.test",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    { "path": "../packages/dinero.js" },
+    { "path": "../packages/calculator-bigint" }
+  ],
+  "include": ["utils"]
+}

--- a/test/utils/castToBigjsCurrency.ts
+++ b/test/utils/castToBigjsCurrency.ts
@@ -1,4 +1,5 @@
 import Big from 'big.js';
+
 import type { Currency } from 'dinero.js';
 
 export function castToBigjsCurrency(currency: Currency<number>): Currency<Big> {

--- a/test/utils/createBigjsDinero.ts
+++ b/test/utils/createBigjsDinero.ts
@@ -1,4 +1,5 @@
 import Big from 'big.js';
+
 import { createDinero } from 'dinero.js';
 import type { DineroOptions, ComparisonOperator } from 'dinero.js';
 

--- a/tsconfig.declaration.json
+++ b/tsconfig.declaration.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "emitDeclarationOnly": true,
     "noEmit": false,
-    "incremental": true,
+    "incremental": true
   }
 }

--- a/tsconfig.declaration.json
+++ b/tsconfig.declaration.json
@@ -1,9 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "incremental": true
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "incremental": true,
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,16 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "ESNEXT"
+    "target": "ESNEXT",
+    "baseUrl": "./",
+    "paths": {
+      "dinero.js": ["packages/dinero.js/src/index"],
+      "@dinero.js/core": ["packages/core/src/index"],
+      "@dinero.js/currencies": ["packages/currencies/src/index"],
+      "@dinero.js/calculator-bigint": ["packages/calculator-bigint/src/index"],
+      "@dinero.js/calculator-number": ["packages/calculator-number/src/index"],
+      "@dinero.js/test": ["test/utils/index.ts"]
+    }
   },
   "exclude": [
     "**/__fixtures__/**/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
       "@dinero.js/currencies": ["packages/currencies/src/index"],
       "@dinero.js/calculator-bigint": ["packages/calculator-bigint/src/index"],
       "@dinero.js/calculator-number": ["packages/calculator-number/src/index"],
-      "@dinero.js/test": ["test/utils/index.ts"]
+      "@dinero.js/test": ["test/utils/index"]
     }
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
       "@dinero.js/currencies": ["packages/currencies/src/index"],
       "@dinero.js/calculator-bigint": ["packages/calculator-bigint/src/index"],
       "@dinero.js/calculator-number": ["packages/calculator-number/src/index"],
-      "@dinero.js/test": ["test/utils/index"]
+      "test-utils": ["test/utils/index"]
     }
   },
   "exclude": [


### PR DESCRIPTION
This is just an idea, it makes the TypeScript compiler a bit smarter. It won't rebuild packages that don't need it. Also it should allow the TypeScript language server to discover package types in development without requiring a rebuild of the types.

This change also allows doing some neat stuff like importing '@dinero.js/test' for the test utils, rather than a long path to get to the top directory in each test.