### PR TITLE
build: quiet api-extractor

### DIFF
--- a/packages/calculator-bigint/package.json
+++ b/packages/calculator-bigint/package.json
@@ -36,7 +36,7 @@
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
     "build:tsc": "tsc -b",
-    "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
+    "build:types": "yarn run build:tsc && api-extractor run --local",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",

--- a/packages/calculator-number/package.json
+++ b/packages/calculator-number/package.json
@@ -36,7 +36,7 @@
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
     "build:tsc": "tsc -b",
-    "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
+    "build:types": "yarn run build:tsc && api-extractor run --local",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
     "build:tsc": "tsc -b",
-    "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
+    "build:types": "yarn run build:tsc && api-extractor run --local",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",

--- a/packages/currencies/package.json
+++ b/packages/currencies/package.json
@@ -40,7 +40,7 @@
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
     "build:tsc": "tsc -b",
-    "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
+    "build:types": "yarn run build:tsc && api-extractor run --local",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",

--- a/packages/dinero.js/package.json
+++ b/packages/dinero.js/package.json
@@ -36,7 +36,7 @@
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
     "build:tsc": "tsc -b",
-    "build:types": "yarn run build:tsc && api-extractor run --local --verbose",
+    "build:types": "yarn run build:tsc && api-extractor run --local",
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",


### PR DESCRIPTION
I had the cli flag `--verbose` on while learning api-extractor, it doesn't need to be on during regular builds.