### PR TITLE
ci(#671): remove duplication of calling prepare

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
       - ~/.cache/yarn
   - &run_yarn_install
     name: Install dependencies
-    command: yarn install --frozen-lockfile
+    command: yarn install --frozen-lockfile --ignore-scripts
   - &restore_dist_folders
     name: Restore dist folders
     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,12 +82,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *attach_workspace
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
       - run: *run_yarn_install
       - save_cache: *save_yarn_cache
-      - run: *restore_dist_folders
       - run:
           name: Linting
           command: yarn run lint
@@ -95,10 +93,12 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - *attach_workspace
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
       - run: *run_yarn_install
       - save_cache: *save_yarn_cache
+      - run: *restore_dist_folders
       - run:
           name: Type checking
           command: yarn run test:types
@@ -106,12 +106,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *attach_workspace
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
       - run: *run_yarn_install
       - save_cache: *save_yarn_cache
-      - run: *restore_dist_folders
       - run:
           name: Unit tests
           command: yarn run test --maxWorkers=4
@@ -134,12 +132,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *attach_workspace
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
       - run: *run_yarn_install
       - save_cache: *save_yarn_cache
-      - run: *restore_dist_folders
       - run:
           name: Release if needed
           command: yarn run shipjs trigger
@@ -149,13 +145,11 @@ workflows:
   ci:
     jobs:
       - build
-      - test_lint:
+      - test_lint
+      - test_types:
           requires:
             - build
-      - test_types
-      - test_unit:
-          requires:
-            - build
+      - test_unit
       - test_size:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,9 @@ jobs:
       - *attach_workspace
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
-      - run: *run_yarn_install
+      - run:
+          name: Install dependencies
+          command: yarn install --frozen-lockfile
       - save_cache: *save_yarn_cache
       - run: *restore_dist_folders
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
       - ~/.cache/yarn
   - &run_yarn_install
     name: Install dependencies
-    command: yarn install --frozen-lockfile --ignore-scripts
+    command: yarn install --frozen-lockfile
   - &restore_dist_folders
     name: Restore dist folders
     command: |
@@ -120,9 +120,7 @@ jobs:
       - *attach_workspace
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
-      - run:
-          name: Install dependencies
-          command: yarn install --frozen-lockfile
+      - run: *run_yarn_install
       - save_cache: *save_yarn_cache
       - run: *restore_dist_folders
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,12 +93,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *attach_workspace
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
       - run: *run_yarn_install
       - save_cache: *save_yarn_cache
-      - run: *restore_dist_folders
       - run:
           name: Type checking
           command: yarn run test:types
@@ -144,9 +142,7 @@ workflows:
     jobs:
       - build
       - test_lint
-      - test_types:
-          requires:
-            - build
+      - test_types
       - test_unit
       - test_size:
           requires:

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -6,8 +6,7 @@
     "packages/currencies",
     "packages/dinero.js"
   ],
-  "buildCommand": false,
-  "^": "buildCommand is false because `yarn prepare` is going to build packages anyway.",
+  "buildCommand": "build",
   "sandboxes": [
     "/examples/cart-react",
     "/examples/cart-vue",

--- a/examples/cart-react/package.json
+++ b/examples/cart-react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dinero.js/example-cart-react",
   "version": "2.0.0-alpha.10",
+  "private": true,
   "scripts": {
     "build:clean": "rimraf ./dist",
     "dev": "vite",

--- a/examples/cart-vue/package.json
+++ b/examples/cart-vue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dinero.js/example-cart-vue",
   "version": "2.0.0-alpha.10",
+  "private": true,
   "scripts": {
     "build:clean": "rimraf ./dist",
     "dev": "vite",

--- a/examples/pricing-react/package.json
+++ b/examples/pricing-react/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dinero.js/example-pricing-react",
+<<<<<<< HEAD
   "version": "2.0.0-alpha.10",
+=======
+  "private": true,
+  "version": "2.0.0-alpha.9",
+>>>>>>> ef49b3a (build: add "private" to examples package.json)
   "scripts": {
     "build:clean": "rimraf ./dist",
     "dev": "vite",

--- a/examples/pricing-react/package.json
+++ b/examples/pricing-react/package.json
@@ -1,11 +1,7 @@
 {
   "name": "@dinero.js/example-pricing-react",
-<<<<<<< HEAD
   "version": "2.0.0-alpha.10",
-=======
   "private": true,
-  "version": "2.0.0-alpha.9",
->>>>>>> ef49b3a (build: add "private" to examples package.json)
   "scripts": {
     "build:clean": "rimraf ./dist",
     "dev": "vite",

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dinero.js/example-starter",
+<<<<<<< HEAD
   "version": "2.0.0-alpha.10",
+=======
+  "version": "2.0.0-alpha.9",
+  "private": true,
+>>>>>>> ef49b3a (build: add "private" to examples package.json)
   "scripts": {
     "build:clean": "rimraf ./dist",
     "dev": "vite",

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -1,11 +1,7 @@
 {
   "name": "@dinero.js/example-starter",
-<<<<<<< HEAD
   "version": "2.0.0-alpha.10",
-=======
-  "version": "2.0.0-alpha.9",
   "private": true,
->>>>>>> ef49b3a (build: add "private" to examples package.json)
   "scripts": {
     "build:clean": "rimraf ./dist",
     "dev": "vite",

--- a/packages/calculator-bigint/package.json
+++ b/packages/calculator-bigint/package.json
@@ -40,7 +40,6 @@
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",
-    "prepare": "yarn build:esm && yarn build:types",
     "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
   },
   "dependencies": {

--- a/packages/calculator-number/package.json
+++ b/packages/calculator-number/package.json
@@ -40,7 +40,6 @@
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",
-    "prepare": "yarn build:esm && yarn build:types",
     "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,6 @@
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",
-    "prepare": "yarn build:esm && yarn build:types",
     "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
   },
   "dependencies": {

--- a/packages/currencies/package.json
+++ b/packages/currencies/package.json
@@ -44,7 +44,6 @@
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",
-    "prepare": "yarn build:esm && yarn build:types",
     "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
   }
 }

--- a/packages/dinero.js/package.json
+++ b/packages/dinero.js/package.json
@@ -40,7 +40,6 @@
     "build:umd:cjs": "rollup --config",
     "build": "yarn build:clean && yarn build:umd:cjs && yarn build:esm && yarn build:types",
     "on:change": "concurrently \"yarn build:esm\" \"yarn build:types\"",
-    "prepare": "yarn build:esm && yarn build:types",
     "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
   },
   "dependencies": {


### PR DESCRIPTION
I noticed `prepare` is automatically run after `yarn install` in every Circle CI job. By adding the flag `--ignore-scripts` it removes duplication.

Closes #671