### PR TITLE
fix: don't accept extra fields inside the currency options on create

### DIFF
--- a/packages/core/src/helpers/createDinero.ts
+++ b/packages/core/src/helpers/createDinero.ts
@@ -12,9 +12,11 @@ export function createDinero<TAmount>({
 }: CreateDineroOptions<TAmount>) {
   return function dinero({
     amount,
-    currency,
-    scale = currency.exponent,
+    currency: { code, base, exponent },
+    scale = exponent,
   }: DineroOptions<TAmount>): Dinero<TAmount> {
+    const currency = { code, base, exponent };
+
     onCreate?.({ amount, currency, scale });
 
     return {

--- a/packages/dinero.js/src/__tests__/dinero.test.ts
+++ b/packages/dinero.js/src/__tests__/dinero.test.ts
@@ -17,4 +17,20 @@ describe('dinero', () => {
 
     expect(snapshot).toMatchObject({ amount: 500, currency: USD, scale: 2 });
   });
+  it('cleans up unwanted properties from the options', () => {
+    const d = dinero({
+      amount: 500,
+      // @ts-expect-error
+      currency: { code: 'USD', exponent: 2, base: 10, _extraProperty: 123 },
+      _extraProperty: 123,
+    });
+
+    const snapshot = toSnapshot(d);
+
+    expect(snapshot).toStrictEqual({
+      amount: 500,
+      currency: USD,
+      scale: 2,
+    });
+  });
 });


### PR DESCRIPTION
In order to save and retrieve dineros to/from our storage layer we map them to a copycat money-type. However, on retrievals we noticed that internal fields were leaking into the currency objects like so:

```
"amount": 0,
"currency": {
    "_type": "currencyObj",  <----
    "base": 10,
    "code": "USD",
    "exponent": 2
},
"scale": 2
```
... and upon further investigation one can pass anything into a dinero's currency object as long as the required subset of fields is met. This change makes the selection of fields as explicit as the base structure's (where `amount`, `currency` and `scale` are taken and everything else ignored).