### PR TITLE
build: fix build failure because of type checking tests

### DIFF
--- a/packages/calculator-bigint/tsconfig.json
+++ b/packages/calculator-bigint/tsconfig.json
@@ -7,5 +7,5 @@
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "references": [{ "path": "../core" }],
-  "include": ["src"]
-}
+  "include": ["src"],
+  "exclude": [ "**/__tests__/**/*"]}

--- a/packages/calculator-number/tsconfig.json
+++ b/packages/calculator-number/tsconfig.json
@@ -7,5 +7,5 @@
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "references": [{ "path": "../core" }],
-  "include": ["src"]
-}
+  "include": ["src"],
+  "exclude": [ "**/__tests__/**/*"]}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,5 +7,6 @@
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "references": [{ "path": "../currencies" }],
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [ "**/__tests__/**/*"]
 }

--- a/packages/currencies/tsconfig.json
+++ b/packages/currencies/tsconfig.json
@@ -6,5 +6,5 @@
     "composite": true,
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
-  "include": ["src"]
-}
+  "include": ["src"],
+  "exclude": [ "**/__tests__/**/*"]}

--- a/packages/dinero.js/tsconfig.json
+++ b/packages/dinero.js/tsconfig.json
@@ -11,5 +11,5 @@
     { "path": "../core" },
     { "path": "../currencies" }
   ],
-  "include": ["src"]
-}
+  "include": ["src"],
+  "exclude": [ "**/__tests__/**/*"]}


### PR DESCRIPTION
I added an exclude directive to the `tsconfig.json` files in the packages.

@sarahdayan wIth this change, I get type errors in my editor for tests files, and the `test:types` fails if there is a type error in a test. Though it doesn't attempt to build the tests, which is why the build is currently failing.