### PR TITLE
refactor: api-extractor config

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -77,7 +77,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/tsconfig.json"
      */
-    "tsconfigFilePath": "<projectFolder>/tsconfig.declaration.json"
+    // "tsconfigFilePath": "<projectFolder>/tsconfig.declaration.json",
     /**
      * Provides a compiler configuration that will be used instead of reading the tsconfig.json file from disk.
      * The object must conform to the TypeScript tsconfig schema:
@@ -88,9 +88,14 @@
      *
      * DEFAULT VALUE: no overrideTsconfig section
      */
-    // "overrideTsconfig": {
-    //   . . .
-    // }
+    "overrideTsconfig": {
+      "$schema": "http://json.schemastore.org/tsconfig",
+
+      "extends": "./tsconfig",
+      "compilerOptions": {
+        "paths": {}
+      }
+    }
     /**
      * This option causes the compiler to be invoked with the --skipLibCheck option. This option is not recommended
      * and may cause API Extractor to produce incomplete or incorrect declarations, but it may be required when
@@ -266,7 +271,7 @@
    *
    * DEFAULT VALUE: "crlf"
    */
-  // "newlineKind": "crlf",
+  "newlineKind": "lf",
 
   /**
    * Configures how API Extractor reports error and warning messages produced during analysis.

--- a/packages/calculator-bigint/tsconfig.declaration.json
+++ b/packages/calculator-bigint/tsconfig.declaration.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "compilerOptions": {
-    "paths": {}
-  }
-}

--- a/packages/calculator-bigint/tsconfig.json
+++ b/packages/calculator-bigint/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "composite": true,
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "references": [{ "path": "../core" }],
   "include": ["src"],
-  "exclude": [ "**/__tests__/**/*"]}
+  "exclude": ["**/__tests__/**/*"]
+}

--- a/packages/calculator-number/tsconfig.declaration.json
+++ b/packages/calculator-number/tsconfig.declaration.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "compilerOptions": {
-    "paths": {}
-  }
-}

--- a/packages/calculator-number/tsconfig.json
+++ b/packages/calculator-number/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "composite": true,
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "references": [{ "path": "../core" }],
   "include": ["src"],
-  "exclude": [ "**/__tests__/**/*"]}
+  "exclude": ["**/__tests__/**/*"]
+}

--- a/packages/core/tsconfig.declaration.json
+++ b/packages/core/tsconfig.declaration.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "compilerOptions": {
-    "paths": {}
-  }
-}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "composite": true,
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "references": [{ "path": "../currencies" }],
   "include": ["src"],
-  "exclude": [ "**/__tests__/**/*"]
+  "exclude": ["**/__tests__/**/*"]
 }

--- a/packages/currencies/tsconfig.declaration.json
+++ b/packages/currencies/tsconfig.declaration.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "compilerOptions": {
-    "paths": {}
-  }
-}

--- a/packages/currencies/tsconfig.json
+++ b/packages/currencies/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "composite": true,
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "include": ["src"],
-  "exclude": [ "**/__tests__/**/*"]}
+  "exclude": ["**/__tests__/**/*"]
+}

--- a/packages/dinero.js/tsconfig.declaration.json
+++ b/packages/dinero.js/tsconfig.declaration.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "compilerOptions": {
-    "paths": {}
-  }
-}

--- a/packages/dinero.js/tsconfig.json
+++ b/packages/dinero.js/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "composite": true,
     "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "references": [
@@ -12,4 +11,5 @@
     { "path": "../currencies" }
   ],
   "include": ["src"],
-  "exclude": [ "**/__tests__/**/*"]}
+  "exclude": ["**/__tests__/**/*"]
+}

--- a/tsconfig.declaration.json
+++ b/tsconfig.declaration.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "emitDeclarationOnly": true,
+    "composite": true,
+    "incremental": true,
     "noEmit": false,
-    "incremental": true
+    "declaration": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ESNEXT",
+    "noEmit": true,
     "baseUrl": "./",
     "paths": {
       "dinero.js": ["packages/dinero.js/src/index"],


### PR DESCRIPTION
Update `api-extractor.json` after learning more about it.

- use `overrideTsconfig` to eliminate the need for `tsconfig.declaration.json` files in the projects
- add `"newlineKind": "lf"` to fix line ending issue