### PR TITLE
build: stop formatting api files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 coverage
 node_modules
 dist
+lib
 build
 website
 **/*.md

--- a/packages/calculator-bigint/etc/calculator-bigint.api.md
+++ b/packages/calculator-bigint/etc/calculator-bigint.api.md
@@ -15,9 +15,7 @@ export const add: BinaryOperation<bigint>;
 // @public (undocumented)
 export const calculator: {
     add: BinaryOperation<bigint, bigint>;
-    compare: BinaryOperation<bigint,
-    ComparisonOperator
-    >;
+    compare: BinaryOperation<bigint, ComparisonOperator>;
     decrement: UnaryOperation<bigint, bigint>;
     increment: UnaryOperation<bigint, bigint>;
     integerDivide: BinaryOperation<bigint, bigint>;

--- a/packages/calculator-number/etc/calculator-number.api.md
+++ b/packages/calculator-number/etc/calculator-number.api.md
@@ -15,9 +15,7 @@ export const add: BinaryOperation<number>;
 // @public (undocumented)
 export const calculator: {
     add: BinaryOperation<number, number>;
-    compare: BinaryOperation<number,
-    ComparisonOperator
-    >;
+    compare: BinaryOperation<number, ComparisonOperator>;
     decrement: UnaryOperation<number, number>;
     increment: UnaryOperation<number, number>;
     integerDivide: BinaryOperation<number, number>;

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -22,10 +22,7 @@ ratios: ReadonlyArray<ScaledAmount<TAmount> | TAmount>
 export function assert(condition: boolean, message: string): void;
 
 // @public (undocumented)
-export type BinaryOperation<TInput, TOutput = TInput> = (
-a: TInput,
-b: TInput
-) => TOutput;
+export type BinaryOperation<TInput, TOutput = TInput> = (a: TInput, b: TInput) => TOutput;
 
 // @public (undocumented)
 export type Calculator<TInput> = {
@@ -55,17 +52,11 @@ export enum ComparisonOperator {
     // (undocumented)
     GT = 1,
     // (undocumented)
-    LT = -1,
+    LT = -1
 }
 
 // @public (undocumented)
-export function convert<TAmount>(
-calculator: Calculator<TAmount>
-): (
-dineroObject: Dinero<TAmount>,
-newCurrency: Currency<TAmount>,
-rates: Rates<TAmount>
-) => Dinero<TAmount>;
+export function convert<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, newCurrency: Currency<TAmount>, rates: Rates<TAmount>) => Dinero<TAmount>;
 
 // @public (undocumented)
 export type ConvertParams<TAmount> = readonly [
@@ -75,14 +66,7 @@ rates: Rates<TAmount>
 ];
 
 // @public (undocumented)
-export function createDinero<TAmount>({
-    calculator,
-    onCreate,
-}: CreateDineroOptions<TAmount>): ({
-    amount,
-    currency: { code, base, exponent },
-    scale,
-}: DineroOptions<TAmount>) => Dinero<TAmount>;
+export function createDinero<TAmount>({ calculator, onCreate, }: CreateDineroOptions<TAmount>): ({ amount, currency: { code, base, exponent }, scale, }: DineroOptions<TAmount>) => Dinero<TAmount>;
 
 // @public (undocumented)
 export type CreateDineroOptions<TAmount> = {
@@ -98,11 +82,7 @@ export type Dinero<TAmount> = {
 };
 
 // @public (undocumented)
-export type DineroFactory<TAmount> = ({
-    amount,
-    currency,
-    scale,
-}: DineroOptions<TAmount>) => Dinero<TAmount>;
+export type DineroFactory<TAmount> = ({ amount, currency, scale, }: DineroOptions<TAmount>) => Dinero<TAmount>;
 
 // @public (undocumented)
 export type DineroOptions<TAmount> = {
@@ -122,9 +102,7 @@ export type DineroSnapshot<TAmount> = {
 export const down: RoundingMode;
 
 // @public (undocumented)
-export function equal<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
+export function equal<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
 
 // @public (undocumented)
 export type EqualParams<TAmount> = readonly [
@@ -133,9 +111,7 @@ comparator: Dinero<TAmount>
 ];
 
 // @public (undocumented)
-export type Formatter<TAmount> = (
-dineroObject: Dinero<TAmount>
-) => string;
+export type Formatter<TAmount> = (dineroObject: Dinero<TAmount>) => string;
 
 // @public (undocumented)
 export type GreaterThanOrEqualParams<TAmount> = readonly [
@@ -168,9 +144,7 @@ export const halfTowardsZero: RoundingMode;
 export const halfUp: RoundingMode;
 
 // @public (undocumented)
-export function hasSubUnits<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>) => boolean;
+export function hasSubUnits<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>) => boolean;
 
 // @public (undocumented)
 export type HasSubUnitsParams<TAmount> = readonly [
@@ -178,9 +152,7 @@ dineroObject: Dinero<TAmount>
 ];
 
 // @public (undocumented)
-export function haveSameAmount<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObjects: readonly Dinero<TAmount>[]) => boolean;
+export function haveSameAmount<TAmount>(calculator: Calculator<TAmount>): (dineroObjects: readonly Dinero<TAmount>[]) => boolean;
 
 // @public (undocumented)
 export type HaveSameAmountParams<TAmount> = readonly [
@@ -188,23 +160,19 @@ dineroObjects: ReadonlyArray<Dinero<TAmount>>
 ];
 
 // @public (undocumented)
-export function haveSameCurrency<TAmount>(
-dineroObjects: ReadonlyArray<Dinero<TAmount>>
-): boolean;
+export function haveSameCurrency<TAmount>(dineroObjects: ReadonlyArray<Dinero<TAmount>>): boolean;
 
 // @public (undocumented)
-export const INVALID_AMOUNT_MESSAGE = 'Amount is invalid.';
+export const INVALID_AMOUNT_MESSAGE = "Amount is invalid.";
 
 // @public (undocumented)
-export const INVALID_RATIOS_MESSAGE = 'Ratios are invalid.';
+export const INVALID_RATIOS_MESSAGE = "Ratios are invalid.";
 
 // @public (undocumented)
-export const INVALID_SCALE_MESSAGE = 'Scale is invalid.';
+export const INVALID_SCALE_MESSAGE = "Scale is invalid.";
 
 // @public (undocumented)
-export function isNegative<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>) => boolean;
+export function isNegative<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>) => boolean;
 
 // @public (undocumented)
 export type IsNegativeParams<TAmount> = readonly [
@@ -212,9 +180,7 @@ dineroObject: Dinero<TAmount>
 ];
 
 // @public (undocumented)
-export function isPositive<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>) => boolean;
+export function isPositive<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>) => boolean;
 
 // @public (undocumented)
 export type IsPositiveParams<TAmount> = readonly [
@@ -222,14 +188,10 @@ dineroObject: Dinero<TAmount>
 ];
 
 // @public (undocumented)
-export function isZero<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>) => boolean;
+export function isZero<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>) => boolean;
 
 // @public (undocumented)
-export type IsZeroParams<TAmount> = readonly [
-dineroObject: Dinero<TAmount>
-];
+export type IsZeroParams<TAmount> = readonly [dineroObject: Dinero<TAmount>];
 
 // @public (undocumented)
 export type LessThanOrEqualParams<TAmount> = readonly [
@@ -254,12 +216,7 @@ dineroObjects: ReadonlyArray<Dinero<TAmount>>
 ];
 
 // @public (undocumented)
-export function multiply<TAmount>(
-calculator: Calculator<TAmount>
-): (
-multiplicand: Dinero<TAmount>,
-multiplier: TAmount | ScaledAmount<TAmount>
-) => Dinero<TAmount>;
+export function multiply<TAmount>(calculator: Calculator<TAmount>): (multiplicand: Dinero<TAmount>, multiplier: TAmount | ScaledAmount<TAmount>) => Dinero<TAmount>;
 
 // @public (undocumented)
 export type MultiplyParams<TAmount> = readonly [
@@ -268,9 +225,7 @@ multiplier: ScaledAmount<TAmount> | TAmount
 ];
 
 // @public (undocumented)
-export function normalizeScale<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObjects: readonly Dinero<TAmount>[]) => Dinero<TAmount>[];
+export function normalizeScale<TAmount>(calculator: Calculator<TAmount>): (dineroObjects: readonly Dinero<TAmount>[]) => Dinero<TAmount>[];
 
 // @public (undocumented)
 export type NormalizeScaleParams<TAmount> = readonly [
@@ -296,55 +251,31 @@ export type RoundingOptions<TAmount> = {
 export function safeAdd<TAmount>(calculator: Calculator<TAmount>): (augend: Dinero<TAmount>, addend: Dinero<TAmount>) => Dinero<TAmount>;
 
 // @public (undocumented)
-export function safeAllocate<TAmount>(
-calculator: Calculator<TAmount>
-): (
-dineroObject: Dinero<TAmount>,
-ratios: readonly (TAmount | ScaledAmount<TAmount>)[]
-) => Dinero<TAmount>[];
+export function safeAllocate<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, ratios: readonly (TAmount | ScaledAmount<TAmount>)[]) => Dinero<TAmount>[];
 
 // @public (undocumented)
-export function safeCompare<TAmount>(
-calculator: Calculator<TAmount>
-): (
-dineroObject: Dinero<TAmount>,
-comparator: Dinero<TAmount>
-) => ComparisonOperator;
+export function safeCompare<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => ComparisonOperator;
 
 // @public (undocumented)
-export function safeGreaterThan<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
+export function safeGreaterThan<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
 
 // @public (undocumented)
-export function safeGreaterThanOrEqual<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
+export function safeGreaterThanOrEqual<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
 
 // @public (undocumented)
-export function safeLessThan<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
+export function safeLessThan<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
 
 // @public (undocumented)
-export function safeLessThanOrEqual<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
+export function safeLessThanOrEqual<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean;
 
 // @public (undocumented)
-export function safeMaximum<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObjects: readonly Dinero<TAmount>[]) => Dinero<TAmount>;
+export function safeMaximum<TAmount>(calculator: Calculator<TAmount>): (dineroObjects: readonly Dinero<TAmount>[]) => Dinero<TAmount>;
 
 // @public (undocumented)
-export function safeMinimum<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObjects: readonly Dinero<TAmount>[]) => Dinero<TAmount>;
+export function safeMinimum<TAmount>(calculator: Calculator<TAmount>): (dineroObjects: readonly Dinero<TAmount>[]) => Dinero<TAmount>;
 
 // @public (undocumented)
-export function safeSubtract<TAmount>(
-calculator: Calculator<TAmount>
-): (minuend: Dinero<TAmount>, subtrahend: Dinero<TAmount>) => Dinero<TAmount>;
+export function safeSubtract<TAmount>(calculator: Calculator<TAmount>): (minuend: Dinero<TAmount>, subtrahend: Dinero<TAmount>) => Dinero<TAmount>;
 
 // @public (undocumented)
 export type ScaledAmount<TAmount> = {
@@ -359,9 +290,7 @@ subtrahend: Dinero<TAmount>
 ];
 
 // @public (undocumented)
-export function toFormat<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>, transformer: Transformer_2<TAmount>) => string;
+export function toFormat<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, transformer: Transformer_2<TAmount>) => string;
 
 // @public (undocumented)
 export type ToFormatParams<TAmount> = readonly [
@@ -370,17 +299,10 @@ transformer: Transformer_2<TAmount>
 ];
 
 // @public (undocumented)
-export function toSnapshot<TAmount>(
-dineroObject: Dinero<TAmount>
-): DineroSnapshot<TAmount>;
+export function toSnapshot<TAmount>(dineroObject: Dinero<TAmount>): DineroSnapshot<TAmount>;
 
 // @public (undocumented)
-export function toUnit<TAmount>(
-calculator: Calculator<TAmount>
-): (
-dineroObject: Dinero<TAmount>,
-options?: RoundingOptions<TAmount> | undefined
-) => number;
+export function toUnit<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, options?: RoundingOptions<TAmount> | undefined) => number;
 
 // @public (undocumented)
 export type ToUnitParams<TAmount> = readonly [
@@ -389,9 +311,7 @@ options?: RoundingOptions<TAmount>
 ];
 
 // @public (undocumented)
-type Transformer_2<TAmount> = (
-options: TransformerOptions<TAmount>
-) => string;
+type Transformer_2<TAmount> = (options: TransformerOptions<TAmount>) => string;
 export { Transformer_2 as Transformer }
 
 // @public (undocumented)
@@ -402,14 +322,10 @@ export type TransformerOptions<TAmount> = {
 };
 
 // @public (undocumented)
-export type TransformOperation<TInput, TOutput = TInput> = (
-input: TInput
-) => TOutput;
+export type TransformOperation<TInput, TOutput = TInput> = (input: TInput) => TOutput;
 
 // @public (undocumented)
-export function transformScale<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>, newScale: TAmount) => Dinero<TAmount>;
+export function transformScale<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>, newScale: TAmount) => Dinero<TAmount>;
 
 // @public (undocumented)
 export type TransformScaleParams<TAmount> = readonly [
@@ -418,27 +334,19 @@ newScale: TAmount
 ];
 
 // @public (undocumented)
-export function trimScale<TAmount>(
-calculator: Calculator<TAmount>
-): (dineroObject: Dinero<TAmount>) => Dinero<TAmount>;
+export function trimScale<TAmount>(calculator: Calculator<TAmount>): (dineroObject: Dinero<TAmount>) => Dinero<TAmount>;
 
 // @public (undocumented)
-export type TrimScaleParams<TAmount> = readonly [
-dineroObject: Dinero<TAmount>
-];
+export type TrimScaleParams<TAmount> = readonly [dineroObject: Dinero<TAmount>];
 
 // @public (undocumented)
-export type UnaryOperation<TInput, TOutput = TInput> = (
-value: TInput
-) => TOutput;
+export type UnaryOperation<TInput, TOutput = TInput> = (value: TInput) => TOutput;
 
 // @public (undocumented)
-export const UNEQUAL_CURRENCIES_MESSAGE =
-'Objects must have the same currency.';
+export const UNEQUAL_CURRENCIES_MESSAGE = "Objects must have the same currency.";
 
 // @public (undocumented)
-export const UNEQUAL_SCALES_MESSAGE =
-'Objects must have the same scale.';
+export const UNEQUAL_SCALES_MESSAGE = "Objects must have the same scale.";
 
 // @public
 export const up: RoundingMode;

--- a/packages/dinero.js/etc/dinero.js.api.md
+++ b/packages/dinero.js/etc/dinero.js.api.md
@@ -51,28 +51,20 @@ import type { TrimScaleParams } from '@dinero.js/core';
 import { up } from '@dinero.js/core';
 
 // @public
-export function add<TAmount>(
-...[augend, addend]: AddParams<TAmount>
-): Dinero<TAmount>;
+export function add<TAmount>(...[augend, addend]: AddParams<TAmount>): Dinero<TAmount>;
 
 // @public
-export function allocate<TAmount>(
-...[dineroObject, ratios]: AllocateParams<TAmount>
-): Dinero<TAmount>[];
+export function allocate<TAmount>(...[dineroObject, ratios]: AllocateParams<TAmount>): Dinero<TAmount>[];
 
 export { Calculator }
 
 // @public
-export function compare<TAmount>(
-...[dineroObject, comparator]: CompareParams<TAmount>
-): ComparisonOperator;
+export function compare<TAmount>(...[dineroObject, comparator]: CompareParams<TAmount>): ComparisonOperator;
 
 export { ComparisonOperator }
 
 // @public
-export function convert<TAmount>(
-...[dineroObject, newCurrency, rates]: ConvertParams<TAmount>
-): Dinero<TAmount>;
+export function convert<TAmount>(...[dineroObject, newCurrency, rates]: ConvertParams<TAmount>): Dinero<TAmount>;
 
 export { createDinero }
 
@@ -81,11 +73,7 @@ export { Currency }
 export { Dinero }
 
 // @public
-export const dinero: ({
-    amount,
-    currency: { code, base, exponent },
-    scale,
-}: DineroOptions<number>) => Dinero<number>;
+export const dinero: ({ amount, currency: { code, base, exponent }, scale, }: DineroOptions<number>) => Dinero<number>;
 
 export { DineroFactory }
 
@@ -96,21 +84,15 @@ export { DineroSnapshot }
 export { down }
 
 // @public
-export function equal<TAmount>(
-...[dineroObject, comparator]: EqualParams<TAmount>
-): boolean;
+export function equal<TAmount>(...[dineroObject, comparator]: EqualParams<TAmount>): boolean;
 
 export { Formatter }
 
 // @public
-export function greaterThan<TAmount>(
-...[dineroObject, comparator]: GreaterThanParams<TAmount>
-): boolean;
+export function greaterThan<TAmount>(...[dineroObject, comparator]: GreaterThanParams<TAmount>): boolean;
 
 // @public
-export function greaterThanOrEqual<TAmount>(
-...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount>
-): boolean;
+export function greaterThanOrEqual<TAmount>(...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount>): boolean;
 
 export { halfAwayFromZero }
 
@@ -125,96 +107,64 @@ export { halfTowardsZero }
 export { halfUp }
 
 // @public
-export function hasSubUnits<TAmount>(
-...[dineroObject]: HasSubUnitsParams<TAmount>
-): boolean;
+export function hasSubUnits<TAmount>(...[dineroObject]: HasSubUnitsParams<TAmount>): boolean;
 
 // @public
-export function haveSameAmount<TAmount>(
-...[dineroObjects]: HaveSameAmountParams<TAmount>
-): boolean;
+export function haveSameAmount<TAmount>(...[dineroObjects]: HaveSameAmountParams<TAmount>): boolean;
 
 // @public
 export const haveSameCurrency: typeof haveSameCurrency_2;
 
 // @public
-export function isNegative<TAmount>(
-...[dineroObject]: IsNegativeParams<TAmount>
-): boolean;
+export function isNegative<TAmount>(...[dineroObject]: IsNegativeParams<TAmount>): boolean;
 
 // @public
-export function isPositive<TAmount>(
-...[dineroObject]: IsPositiveParams<TAmount>
-): boolean;
+export function isPositive<TAmount>(...[dineroObject]: IsPositiveParams<TAmount>): boolean;
 
 // @public
-export function isZero<TAmount>(
-...[dineroObject]: IsZeroParams<TAmount>
-): boolean;
+export function isZero<TAmount>(...[dineroObject]: IsZeroParams<TAmount>): boolean;
 
 // @public
-export function lessThan<TAmount>(
-...[dineroObject, comparator]: LessThanParams<TAmount>
-): boolean;
+export function lessThan<TAmount>(...[dineroObject, comparator]: LessThanParams<TAmount>): boolean;
 
 // @public
-export function lessThanOrEqual<TAmount>(
-...[dineroObject, comparator]: LessThanOrEqualParams<TAmount>
-): boolean;
+export function lessThanOrEqual<TAmount>(...[dineroObject, comparator]: LessThanOrEqualParams<TAmount>): boolean;
 
 // @public
-export function maximum<TAmount>(
-...[dineroObjects]: MaximumParams<TAmount>
-): Dinero<TAmount>;
+export function maximum<TAmount>(...[dineroObjects]: MaximumParams<TAmount>): Dinero<TAmount>;
 
 // @public
-export function minimum<TAmount>(
-...[dineroObjects]: MinimumParams<TAmount>
-): Dinero<TAmount>;
+export function minimum<TAmount>(...[dineroObjects]: MinimumParams<TAmount>): Dinero<TAmount>;
 
 // @public
-export function multiply<TAmount>(
-...[multiplicand, multiplier]: MultiplyParams<TAmount>
-): Dinero<TAmount>;
+export function multiply<TAmount>(...[multiplicand, multiplier]: MultiplyParams<TAmount>): Dinero<TAmount>;
 
 // @public
-export function normalizeScale<TAmount>(
-...[dineroObjects]: NormalizeScaleParams<TAmount>
-): Dinero<TAmount>[];
+export function normalizeScale<TAmount>(...[dineroObjects]: NormalizeScaleParams<TAmount>): Dinero<TAmount>[];
 
 export { Rates }
 
 export { RoundingOptions }
 
 // @public
-export function subtract<TAmount>(
-...[minuend, subtrahend]: SubtractParams<TAmount>
-): Dinero<TAmount>;
+export function subtract<TAmount>(...[minuend, subtrahend]: SubtractParams<TAmount>): Dinero<TAmount>;
 
 // @public
-export function toFormat<TAmount>(
-...[dineroObject, transformer]: ToFormatParams<TAmount>
-): string;
+export function toFormat<TAmount>(...[dineroObject, transformer]: ToFormatParams<TAmount>): string;
 
 // @public
 export const toSnapshot: typeof toSnapshot_2;
 
 // @public
-export function toUnit<TAmount>(
-...[dineroObject, options]: ToUnitParams<TAmount>
-): number;
+export function toUnit<TAmount>(...[dineroObject, options]: ToUnitParams<TAmount>): number;
 
 export { Transformer_2 as Transformer }
 
 // @public
-export function transformScale<TAmount>(
-...[dineroObject, newScale]: TransformScaleParams<TAmount>
-): Dinero<TAmount>;
+export function transformScale<TAmount>(...[dineroObject, newScale]: TransformScaleParams<TAmount>): Dinero<TAmount>;
 
 // @public
-export function trimScale<TAmount>(
-...[dineroObject]: TrimScaleParams<TAmount>
-): Dinero<TAmount>;
+export function trimScale<TAmount>(...[dineroObject]: TrimScaleParams<TAmount>): Dinero<TAmount>;
 
 export { up }
 


### PR DESCRIPTION
I finally figured out why the `*.api.md` files kept being reformatted! `api-extractor` uses the code in the `lib` folder to build the api files, but it wasn't ignored by Prettier so anytime the script `format` ran it would format all the files in the lib folders, then on the next run of `build:types` the reformatted code was used!

## Changes in this PR

- Add `lib` to `.prettierignore`
- Rebuild all the `*.api.md` files to original output from `api-extractor`

Now the `*.api.md` files should only change if the api does.