### PR TITLE
fix(toDecimal): preserve negative sign for leading zeros

### DIFF
--- a/packages/core/src/api/toDecimal.ts
+++ b/packages/core/src/api/toDecimal.ts
@@ -54,17 +54,17 @@ function getDecimal<TAmount>(
   const zero = calculator.zero();
 
   return (units: readonly TAmount[], scale: TAmount) => {
-    const integer = formatter.toString(units[0]);
+    const whole = formatter.toString(units[0]);
     const fractional = formatter.toString(absoluteFn(units[1]));
 
     const scaleNumber = formatter.toNumber(scale);
-    const decimal = `${integer}.${fractional.padStart(scaleNumber, '0')}`;
+    const decimal = `${whole}.${fractional.padStart(scaleNumber, '0')}`;
 
-    // A leading negative zero is a special case because the toString
-    // formatter (generally String) won't preserve its negative sign.
     const leadsWithZero = equalFn(units[0], zero);
     const isNegative = lessThanFn(units[1], zero);
 
+    // A leading negative zero is a special case because the `toString`
+    // formatter won't preserve its negative sign (since 0 === -0).
     return leadsWithZero && isNegative ? `-${decimal}` : decimal;
   };
 }

--- a/packages/core/src/api/toDecimal.ts
+++ b/packages/core/src/api/toDecimal.ts
@@ -1,7 +1,7 @@
 import { NON_DECIMAL_CURRENCY_MESSAGE } from '../checks';
 import { assert } from '../helpers';
 import type { Calculator, Dinero, Formatter, Transformer } from '../types';
-import { absolute, computeBase, equal, isArray } from '../utils';
+import { absolute, computeBase, equal, isArray, lessThan } from '../utils';
 
 import { toUnits } from './toUnits';
 
@@ -49,23 +49,22 @@ function getDecimal<TAmount>(
   formatter: Formatter<TAmount>
 ) {
   const absoluteFn = absolute(calculator);
+  const equalFn = equal(calculator);
+  const lessThanFn = lessThan(calculator);
+  const zero = calculator.zero();
 
   return (units: readonly TAmount[], scale: TAmount) => {
-    return units
-      .map((unit, index) => {
-        const isFirst = index === 0;
-        const isLast = units.length - 1 === index;
+    const integer = formatter.toString(units[0]);
+    const fractional = formatter.toString(absoluteFn(units[1]));
 
-        const unitAsString = formatter.toString(
-          isFirst ? unit : absoluteFn(unit)
-        );
+    const scaleNumber = formatter.toNumber(scale);
+    const decimal = `${integer}.${fractional.padStart(scaleNumber, '0')}`;
 
-        if (isLast) {
-          return unitAsString.padStart(formatter.toNumber(scale), '0');
-        }
+    // A leading negative zero is a special case because the toString
+    // formatter (generally String) won't preserve its negative sign.
+    const leadsWithZero = equalFn(units[0], zero);
+    const isNegative = lessThanFn(units[1], zero);
 
-        return unitAsString;
-      })
-      .join('.');
+    return leadsWithZero && isNegative ? `-${decimal}` : decimal;
   };
 }

--- a/packages/dinero.js/src/api/__tests__/toDecimal.test.ts
+++ b/packages/dinero.js/src/api/__tests__/toDecimal.test.ts
@@ -45,6 +45,16 @@ describe('toDecimal', () => {
 
         expect(toDecimal(d)).toEqual('-10.50');
       });
+      it('returns the negative amount with a leading zero in decimal format', () => {
+        const d = dinero({ amount: -1, currency: USD });
+
+        expect(toDecimal(d)).toEqual('-0.01');
+      });
+      it('returns negative zero amount as a positive value in decimal format', () => {
+        const d = dinero({ amount: -0, currency: USD });
+
+        expect(toDecimal(d)).toEqual('0.00');
+      });
       it('uses a custom transformer', () => {
         const d = dinero({ amount: 1050, currency: USD });
 
@@ -117,6 +127,16 @@ describe('toDecimal', () => {
         const d = dinero({ amount: -1050n, currency: bigintUSD });
 
         expect(toDecimal(d)).toEqual('-10.50');
+      });
+      it('returns the negative amount with a leading zero in decimal format', () => {
+        const d = dinero({ amount: -1n, currency: bigintUSD });
+
+        expect(toDecimal(d)).toEqual('-0.01');
+      });
+      it('returns negative zero amount as a positive value in decimal format', () => {
+        const d = dinero({ amount: -0n, currency: bigintUSD });
+
+        expect(toDecimal(d)).toEqual('0.00');
       });
       it('uses a custom transformer', () => {
         const d = dinero({ amount: 1050n, currency: bigintUSD });
@@ -197,6 +217,16 @@ describe('toDecimal', () => {
         const d = dinero({ amount: new Big(-1005), currency: bigjsUSD });
 
         expect(toDecimal(d)).toEqual('-10.05');
+      });
+      it('returns the negative amount with a leading zero in decimal format', () => {
+        const d = dinero({ amount: new Big(-1), currency: bigjsUSD });
+
+        expect(toDecimal(d)).toEqual('-0.01');
+      });
+      it('returns negative zero amount as a positive value in decimal format', () => {
+        const d = dinero({ amount: new Big(-0), currency: bigjsUSD });
+
+        expect(toDecimal(d)).toEqual('0.00');
       });
       it('uses a custom transformer', () => {
         const d = dinero({ amount: new Big(1050), currency: bigjsUSD });


### PR DESCRIPTION
Change #690 fixed the general case of formatting negative unit values, but was one remaining case where formatting was still incorrect: when the first unit is -0, the resulting string didn't include the leading negative sign.

This change identifies that exact case (negative value, leading zero) and pads the resulting string with a leading negative sign.

Fixes #692