### PR TITLE
refactor: move constants into closures

### DIFF
--- a/packages/core/src/api/hasSubUnits.ts
+++ b/packages/core/src/api/hasSubUnits.ts
@@ -8,6 +8,7 @@ export type HasSubUnitsParams<TAmount> = readonly [
 export function hasSubUnits<TAmount>(calculator: Calculator<TAmount>) {
   const equalFn = equal(calculator);
   const computeBaseFn = computeBase(calculator);
+  const zero = calculator.zero();
 
   return function _hasSubUnits(...[dineroObject]: HasSubUnitsParams<TAmount>) {
     const { amount, currency, scale } = dineroObject.toJSON();
@@ -15,7 +16,7 @@ export function hasSubUnits<TAmount>(calculator: Calculator<TAmount>) {
 
     return !equalFn(
       calculator.modulo(amount, calculator.power(base, scale)),
-      calculator.zero()
+      zero
     );
   };
 }

--- a/packages/core/src/api/isNegative.ts
+++ b/packages/core/src/api/isNegative.ts
@@ -7,10 +7,11 @@ export type IsNegativeParams<TAmount> = readonly [
 
 export function isNegative<TAmount>(calculator: Calculator<TAmount>) {
   const lessThanFn = lessThan(calculator);
+  const zero = calculator.zero();
 
   return function _isNegative(...[dineroObject]: IsNegativeParams<TAmount>) {
     const { amount } = dineroObject.toJSON();
 
-    return lessThanFn(amount, calculator.zero());
+    return lessThanFn(amount, zero);
   };
 }

--- a/packages/core/src/api/isPositive.ts
+++ b/packages/core/src/api/isPositive.ts
@@ -7,10 +7,11 @@ export type IsPositiveParams<TAmount> = readonly [
 
 export function isPositive<TAmount>(calculator: Calculator<TAmount>) {
   const greaterThanOrEqualFn = greaterThanOrEqual(calculator);
+  const zero = calculator.zero();
 
   return function _isPositive(...[dineroObject]: IsPositiveParams<TAmount>) {
     const { amount } = dineroObject.toJSON();
 
-    return greaterThanOrEqualFn(amount, calculator.zero());
+    return greaterThanOrEqualFn(amount, zero);
   };
 }

--- a/packages/core/src/api/isZero.ts
+++ b/packages/core/src/api/isZero.ts
@@ -5,10 +5,11 @@ export type IsZeroParams<TAmount> = readonly [dineroObject: Dinero<TAmount>];
 
 export function isZero<TAmount>(calculator: Calculator<TAmount>) {
   const equalFn = equal(calculator);
+  const zero = calculator.zero();
 
   return function _isZero(...[dineroObject]: IsZeroParams<TAmount>) {
     const { amount } = dineroObject.toJSON();
 
-    return equalFn(amount, calculator.zero());
+    return equalFn(amount, zero);
   };
 }

--- a/packages/core/src/api/normalizeScale.ts
+++ b/packages/core/src/api/normalizeScale.ts
@@ -11,6 +11,7 @@ export function normalizeScale<TAmount>(calculator: Calculator<TAmount>) {
   const maximumFn = maximum(calculator);
   const convertScaleFn = transformScale(calculator);
   const equalFn = equal(calculator);
+  const zero = calculator.zero();
 
   return function _normalizeScale(
     ...[dineroObjects]: NormalizeScaleParams<TAmount>
@@ -19,7 +20,7 @@ export function normalizeScale<TAmount>(calculator: Calculator<TAmount>) {
       const { scale } = current.toJSON();
 
       return maximumFn([highest, scale]);
-    }, calculator.zero());
+    }, zero);
 
     return dineroObjects.map((d) => {
       const { scale } = d.toJSON();

--- a/packages/core/src/api/toDecimal.ts
+++ b/packages/core/src/api/toDecimal.ts
@@ -14,6 +14,8 @@ export function toDecimal<TAmount, TOutput>(calculator: Calculator<TAmount>) {
   const toUnitsFn = toUnits<TAmount, readonly TAmount[]>(calculator);
   const computeBaseFn = computeBase(calculator);
   const equalFn = equal(calculator);
+  const zero = calculator.zero();
+  const ten = new Array(10).fill(null).reduce(calculator.increment, zero);
 
   return function toDecimalFn(
     ...[dineroObject, transformer]: ToDecimalParams<TAmount, TOutput>
@@ -21,8 +23,6 @@ export function toDecimal<TAmount, TOutput>(calculator: Calculator<TAmount>) {
     const { currency, scale } = dineroObject.toJSON();
 
     const base = computeBaseFn(currency.base);
-    const zero = calculator.zero();
-    const ten = new Array(10).fill(null).reduce(calculator.increment, zero);
 
     const isMultiBase = isArray(currency.base);
     const isBaseTen = equalFn(calculator.modulo(base, ten), zero);

--- a/packages/core/src/utils/absolute.ts
+++ b/packages/core/src/utils/absolute.ts
@@ -7,6 +7,7 @@ export function absolute<TAmount>(calculator: Calculator<TAmount>) {
   const equalFn = equal(calculator);
   const lessThanFn = lessThan(calculator);
   const zero = calculator.zero();
+  const minusOne = calculator.decrement(zero);
 
   return (input: TAmount) => {
     if (equalFn(input, zero)) {
@@ -14,8 +15,6 @@ export function absolute<TAmount>(calculator: Calculator<TAmount>) {
     }
 
     if (lessThanFn(input, zero)) {
-      const minusOne = calculator.decrement(zero);
-
       return calculator.multiply(minusOne, input);
     }
 

--- a/packages/core/src/utils/countTrailingZeros.ts
+++ b/packages/core/src/utils/countTrailingZeros.ts
@@ -9,12 +9,11 @@ export function countTrailingZeros<TAmount>(
   calculator: CountTrailingZerosCalculator<TAmount>
 ) {
   const equalFn = equal(calculator);
+  const zero = calculator.zero();
 
   return (input: TAmount, base: TAmount) => {
-    const zero = calculator.zero();
-
     if (equalFn(zero, input)) {
-      return calculator.zero();
+      return zero;
     }
 
     let i = zero;

--- a/packages/core/src/utils/distribute.ts
+++ b/packages/core/src/utils/distribute.ts
@@ -25,6 +25,7 @@ export function distribute<TAmount>(calculator: DistributeCalculator<TAmount>) {
 
     const zero = calculator.zero();
     const one = calculator.increment(zero);
+    const minusOne = calculator.decrement(zero);
 
     const total = ratios.reduce((a, b) => calculator.add(a, b), zero);
 
@@ -46,7 +47,7 @@ export function distribute<TAmount>(calculator: DistributeCalculator<TAmount>) {
 
     const isPositive = greaterThanOrEqualFn(value, zero);
     const compare = isPositive ? greaterThanFn : lessThanFn;
-    const amount = isPositive ? one : calculator.decrement(zero);
+    const amount = isPositive ? one : minusOne;
 
     let i = 0;
 

--- a/packages/core/src/utils/sign.ts
+++ b/packages/core/src/utils/sign.ts
@@ -7,14 +7,13 @@ export function sign<TAmount>(calculator: Calculator<TAmount>) {
   const equalFn = equal(calculator);
   const lessThanFn = lessThan(calculator);
   const zero = calculator.zero();
+  const one = calculator.increment(zero);
+  const minusOne = calculator.decrement(zero);
 
   return (input: TAmount) => {
     if (equalFn(input, zero)) {
       return zero;
     }
-
-    const one = calculator.increment(zero);
-    const minusOne = calculator.decrement(zero);
 
     return lessThanFn(input, zero) ? minusOne : one;
   };


### PR DESCRIPTION
I noticed that not all of the constants were included in the closures of the core functions. There is no reason to recalculate these values because they will never change.