### PR TITLE
build: add `.next` directory to Turborepo build outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -31,7 +31,7 @@
     },
     "build": {
       "dependsOn": ["^build", "build:esm", "build:umd:cjs", "build:types"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", ".next/**/*"]
     },
     "lint": {
       "inputs": ["**/*.ts", "**/*.js"],

--- a/turbo.json
+++ b/turbo.json
@@ -31,7 +31,7 @@
     },
     "build": {
       "dependsOn": ["^build", "build:esm", "build:umd:cjs", "build:types"],
-      "outputs": ["dist/**", ".next/**/*"]
+      "outputs": ["dist/**", ".next/**"]
     },
     "lint": {
       "inputs": ["**/*.ts", "**/*.js"],


### PR DESCRIPTION
@sarahdayan turbo wasn't caching the `.next` directory. So when it tried to use the cache it would fail. I think this should do it!