### PR TITLE
ci: add github action workflow

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,20 @@
+name: Build package
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build package
+      shell: bash
+      run: yarn build
+
+    - name: Test package
+      shell: bash
+      run: yarn test
+
+    - name: Lint package
+      shell: bash
+      run: yarn lint
+
+    - name: Type check package
+      shell: bash
+      run: yarn run check

--- a/.github/actions/setup-env/README.md
+++ b/.github/actions/setup-env/README.md
@@ -1,0 +1,45 @@
+# turbo/setup-env.yml
+
+This is a composite action to simplify a Node, Yarn and TurboRepo CI workflow.
+
+## What does it do
+
+It wraps [felixmosh/turborepo-gh-artifacts](https://github.com/johnhooks/turborepo-gh-artifacts) in a Node.js v16 environment with cached Yarn dependencies.
+
+## Setup
+
+1. Add a `TURBO_TOKEN` environment secret to GitHub repository `Settings > Security > Secrete > Actions`.
+
+2. Add environment variables to the workflow to enable `turbo` remote caching.
+
+```yaml
+env:
+  TURBO_API: 'http://127.0.0.1:9080'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # The team can be anything, it isn't used by local caching but necessary for `turbo`.
+  TURBO_TEAM: 'dinero'
+  TURBO_REMOTE_ONLY: true
+```
+
+2. Add the action as a step in the workflow.
+
+```yaml
+jobs:
+  build:
+    steps:
+      - name: Prepare environment
+        uses: ./.github/actions/turbo
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Security
+
+The `GITHUB_TOKEN` needs to be configured to have the following permissions:
+- read access on the repo
+- no write access, otherwise a PR could wipe out the repo?!?
+-  to upload and download artifacts.
+
+## References
+
+- [Setting the permissions of the GITHUB_TOKEN](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository)

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,43 @@
+name: Setup Node.js environment
+
+inputs:
+  repo-token:
+    description: 'Token to access the repo'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    - name: Turborepo local server
+      uses: felixmosh/turborepo-gh-artifacts@v2.1.0
+      with:
+        repo-token: ${{ inputs.repo-token }}
+
+    - name: Install specific Yarn version
+      shell: bash
+      run: |
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.19
+        echo 'export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"' >> $GITHUB_PATH
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      shell: bash
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache node_modules
+      uses: actions/cache@v3
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install Packages
+      shell: bash
+      run: yarn install --frozen-lockfile

--- a/.github/actions/turbo/README.md
+++ b/.github/actions/turbo/README.md
@@ -1,0 +1,34 @@
+# turbo/action.yml
+
+This is a composite action to simplify a Node, Yarn and TurboRepo CI workflow.
+
+## What does it do
+
+It wraps [felixmosh/turborepo-gh-artifacts](https://github.com/johnhooks/turborepo-gh-artifacts) in a Node.js v16 environment with cached Yarn dependencies.
+
+## Setup
+
+1. Add a `TURBO_TOKEN` environment secret to GitHub repository `Settings > Security > Secrete > Actions`.
+
+2. Add environment variables to the workflow to enable `turbo` remote caching.
+
+```yaml
+env:
+  TURBO_API: 'http://127.0.0.1:9080'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # The team can be anything, it isn't used by local caching but necessary for `turbo`.
+  TURBO_TEAM: 'dinero'
+  TURBO_REMOTE_ONLY: true
+```
+
+2. Add the action as a step in the workflow.
+
+```yaml
+jobs:
+  build:
+    steps:
+      - name: Prepare environment
+        uses: ./.github/actions/turbo
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/.github/actions/turbo/action.yml
+++ b/.github/actions/turbo/action.yml
@@ -1,0 +1,44 @@
+name: Prepare environment
+
+inputs:
+  repo-token:
+    description: 'Token to access the repo'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    - name: Turborepo local server
+      uses: felixmosh/turborepo-gh-artifacts@v2.1.0
+      with:
+        repo-token: ${{ inputs.repo-token }}
+
+    - name: Install specific Yarn version
+      shell: bash
+      run: |
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.19
+        echo 'export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"' >> $GITHUB_PATH
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      shell: bash
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache node_modules
+      uses: actions/cache@v3
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install Packages
+      shell: bash
+      run: yarn install --frozen-lockfile
+      env:
+        CI: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,78 @@
+name: Check Pull Request
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - '**/*'
+
+env:
+  # environment variables to config `turbo` to use the local cache server
+  TURBO_API: 'http://127.0.0.1:9080'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: 'dinero'
+  # Used by scripts/build-types.mjs
+  CI: true
+
+permissions:
+  checks: write
+  contents: read
+  statuses: write
+  pull-requests: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        run: yarn build
+  lint:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint
+        run: yarn lint
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test
+        run: yarn test
+  test-types:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test types
+        run: yarn test:types
+  test-size:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test bundle size
+        run: yarn test:size

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release if needed
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  # environment variables to config `turbo` to use the local cache server
+  TURBO_API: 'http://127.0.0.1:9080'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: 'dinero'
+  # Used by scripts/build-types.mjs
+  CI: true
+
+permissions:
+  checks: write
+  contents: read
+  statuses: write
+  pull-requests: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        run: yarn build
+  lint:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint
+        run: yarn lint
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test
+        run: yarn test
+  test-types:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test types
+        run: yarn test:types
+  test-size:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test bundle size
+        run: yarn test:size
+  release:
+    runs-on: ubuntu-latest
+    needs: [build, lint, test, test-types, test-size]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Environment
+        uses: ./.github/actions/turbo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release if needed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        shell: bash
+        run: yarn run shipjs trigger


### PR DESCRIPTION
This pull request adds a GitHub workflow to the repo. It uses a third party action [felixmosh/turborepo-gh-artifacts](https://github.com/johnhooks/turborepo-gh-artifacts) to create a local TurboRepo cache server and handles uploading/downloading the cache as GitHub artifacts .

To implement, the following environment variables would need to be added:

- `NPM_AUTH_TOKEN` - required to release with `shipjs`.
- `TURBO_TOKEN` - this can be anything, it is used to authorize communication between `turbo` and the local caching server.

Closes #684 