### PR TITLE
ci: update Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/dinero.js
   docker:
-    - image: circleci/node:16.13.1
+    - image: cimg/node:16.13.1
   environment:
     CI: true
 
@@ -178,3 +178,4 @@ workflows:
           filters:
             branches:
               only: main
+# VS Code Extension Version: 1.5.1


### PR DESCRIPTION
The old `circleci` convenience Docker images have been [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) for over a year. This updates the Node.js image with the [next-gen CircleCI convenience images](https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/).