### PR TITLE
refactor(exec): resolve/reject exit code

### DIFF
--- a/scripts/build-types.mjs
+++ b/scripts/build-types.mjs
@@ -17,7 +17,7 @@ const args = process.argv.slice(2).filter((arg) => arg !== '--local');
 // const localFlag = process.env.CI ? [] : ['--local'];
 
 /**
- * ApiExtractor CLI arguments
+ * ApiExtractor CLI arguments.
  */
 const apiExtractorArgs = ['run', '--local', ...args /* , ...localFlag */];
 
@@ -25,7 +25,6 @@ console.log(`api-extractor ${apiExtractorArgs.join(' ')}`);
 
 exec(apiExtractorPath, apiExtractorArgs)
   .then(() => process.exit(0))
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
+  .catch((code) => {
+    process.exit(code);
   });

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -11,7 +11,7 @@ const eslintPath = path.resolve(
 const args = process.argv.slice(2);
 
 /**
- * ESLint CLI arguments
+ * ESLint CLI arguments.
  *
  * ESlint needs to be run in each project for `turbo` to cache the results, so
  * it doesn't look up the file tree for `.eslintrc` or `.eslintignore`.
@@ -26,7 +26,6 @@ console.log(`eslint ${eslintArgs.join(' ')}`);
 
 exec(eslintPath, eslintArgs)
   .then(() => process.exit(0))
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
+  .catch((code) => {
+    process.exit(code);
   });

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -16,7 +16,7 @@ const args = process.argv.slice(2);
 const maxWorkers = process.env.CI ? ['--maxWorkers=4'] : [];
 
 /**
- * Jest CLI arguments
+ * Jest CLI arguments.
  */
 const jestArgs = [...args, ...maxWorkers];
 
@@ -24,7 +24,6 @@ console.log(`jest ${jestArgs.join(' ')}`);
 
 exec(jestPath, jestArgs, { cwd: rootDir })
   .then(() => process.exit(0))
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
+  .catch((code) => {
+    process.exit(code);
   });

--- a/scripts/utils/exec.mjs
+++ b/scripts/utils/exec.mjs
@@ -3,12 +3,12 @@ import { spawn } from 'cross-spawn';
 /**
  * Async `exec`.
  *
- * Inspired by `remix-run` build scripts
- * https://github.com/remix-run/remix/blob/534e1ec071f17654a4db8622e30d6ff70548ce26/scripts/build.mjs
+ * Inspired by `remix-run` build [scripts](https://github.com/remix-run/remix/blob/534e1ec071f17654a4db8622e30d6ff70548ce26/scripts/build.mjs).
  *
  * @param {string} command - Shell command to execute.
  * @param {string[]} [args] - Command arguments.
  * @param {import('node:child_process').SpawnOptions} options - Options to pass to `cross-spawn`.
+ * @returns {Promise<void>} Returns a Promise which resolves when `command` exits. If the exit code is non-zero, it rejects with the exit code.
  */
 export function exec(command, args = [], options = {}) {
   /** @type {(data: Error) => any} */
@@ -31,7 +31,7 @@ export function exec(command, args = [], options = {}) {
       if (code === 0) {
         resolve(void 0);
       } else {
-        reject(new Error(`${command} exited with code ${code}`));
+        reject(code);
       }
     });
   });


### PR DESCRIPTION
The previous behavior was to reject an Error if the command being executed returned a non zero exit code. Though all the stderr output was already passed through, and the rejected error wasn't handled so it caused an unhandled promise rejection, which left unhelpful noise in the build output log.

Also, modified the JSDoc comments to follow the ESLint rule `jsdoc/require-description-complete-sentence`.