### PR TITLE
fix(up, down, halfUp): fix handling of numbers close to 0 and rounding of integer results

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-promise": "6.1.1",
     "eslint-plugin-sonarjs": "0.16.0",
+    "fast-check": "3.6.3",
     "husky": "8.0.1",
     "jest": "28.1.3",
     "jest-watch-typeahead": "1.1.0",

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -102,7 +102,7 @@ export type DineroSnapshot<TAmount> = {
 // @public (undocumented)
 export type DivideOperation = <TAmount>(amount: TAmount, factor: TAmount, calculator: Calculator<TAmount>) => TAmount;
 
-// @public (undocumented)
+// @public
 export const down: DivideOperation;
 
 // @public (undocumented)
@@ -132,22 +132,22 @@ dineroObject: Dinero<TAmount>,
 comparator: Dinero<TAmount>
 ];
 
-// @public (undocumented)
+// @public
 export const halfAwayFromZero: DivideOperation;
 
-// @public (undocumented)
+// @public
 export const halfDown: DivideOperation;
 
-// @public (undocumented)
+// @public
 export const halfEven: DivideOperation;
 
-// @public (undocumented)
+// @public
 export const halfOdd: DivideOperation;
 
-// @public (undocumented)
+// @public
 export const halfTowardsZero: DivideOperation;
 
-// @public (undocumented)
+// @public
 export const halfUp: DivideOperation;
 
 // @public (undocumented)
@@ -346,7 +346,7 @@ export const UNEQUAL_CURRENCIES_MESSAGE = "Objects must have the same currency."
 // @public (undocumented)
 export const UNEQUAL_SCALES_MESSAGE = "Objects must have the same scale.";
 
-// @public (undocumented)
+// @public
 export const up: DivideOperation;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/core/src/divide/__tests__/down.test.ts
+++ b/packages/core/src/divide/__tests__/down.test.ts
@@ -4,11 +4,14 @@ import { down } from '../down';
 
 describe('down', () => {
   describe('decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(down(20, 10, calculator)).toBe(2);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(down(-20, 10, calculator)).toBe(-2);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(down(0, 10, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(down(14, 10, calculator)).toBe(1);
@@ -28,40 +31,16 @@ describe('down', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(down(-16, 10, calculator)).toBe(-2);
     });
-    it('rounds to 0 with a positive quotient above half that is close to 0', () => {
-      expect(down(6, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with a positive half quotient that is close to 0', () => {
-      expect(down(5, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
-      expect(down(4, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(down(1, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(down(0, 10, calculator)).toBe(0);
-    });
-    it('rounds to -1 with amount 1 and a negative quotient below half that is close to 0', () => {
-      expect(down(-1, 10, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative quotient close to and below half, that is close to 0', () => {
-      expect(down(-4, 10, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative half quotient that is close to 0', () => {
-      expect(down(-5, 10, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
-      expect(down(-6, 10, calculator)).toBe(-1);
-    });
   });
   describe('non-decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(down(20, 5, calculator)).toBe(4);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(down(-20, 5, calculator)).toBe(-4);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(down(0, 5, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(down(22, 5, calculator)).toBe(4);
@@ -80,27 +59,6 @@ describe('down', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(down(-24, 5, calculator)).toBe(-5);
-    });
-    it('rounds to 0 with a positive quotient above half that is close to 0', () => {
-      expect(down(3, 5, calculator)).toBe(0);
-    });
-    it('rounds to 0 with a positive half quotient that is close to 0', () => {
-      expect(down(3, 6, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(down(1, 5, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(down(0, 5, calculator)).toBe(0);
-    });
-    it('rounds to -1 with amount -1 and a negative quotient below half that is close to 0', () => {
-      expect(down(-1, 5, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative half quotient that is close to 0', () => {
-      expect(down(-3, 6, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
-      expect(down(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/down.test.ts
+++ b/packages/core/src/divide/__tests__/down.test.ts
@@ -4,6 +4,12 @@ import { down } from '../down';
 
 describe('down', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(down(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(down(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(down(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('down', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(down(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 0 with a positive quotient above half that is close to 0', () => {
+      expect(down(6, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(down(5, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(down(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(down(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(down(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -1 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(down(-1, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(down(-4, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(down(-5, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(down(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(down(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(down(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(down(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('down', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(down(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 0 with a positive quotient above half that is close to 0', () => {
+      expect(down(3, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(down(3, 6, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(down(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(down(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -1 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(down(-1, 5, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(down(-3, 6, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(down(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/down.test.ts
+++ b/packages/core/src/divide/__tests__/down.test.ts
@@ -1,4 +1,5 @@
 import { calculator } from '@dinero.js/calculator-number';
+import * as fc from 'fast-check';
 
 import { down } from '../down';
 
@@ -13,23 +14,25 @@ describe('down', () => {
     it('does not round with a zero quotient', () => {
       expect(down(0, 10, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(down(14, 10, calculator)).toBe(1);
-    });
-    it('rounds down with a negative quotient below half', () => {
-      expect(down(-14, 10, calculator)).toBe(-2);
-    });
     it('rounds down with a positive half quotient', () => {
       expect(down(15, 10, calculator)).toBe(1);
     });
     it('rounds down with a negative half quotient', () => {
       expect(down(-15, 10, calculator)).toBe(-2);
     });
-    it('rounds down with a positive quotient above half', () => {
-      expect(down(16, 10, calculator)).toBe(1);
+    it('rounds down with any positive float quotient', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 9 }), (a) => {
+          expect(down(a, 10, calculator)).toBe(0);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(down(-16, 10, calculator)).toBe(-2);
+    it('rounds down with any negative float quotient', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -9, max: -1 }), (a) => {
+          expect(down(a, 10, calculator)).toBe(-1);
+        })
+      );
     });
   });
   describe('non-decimal factors', () => {
@@ -42,23 +45,25 @@ describe('down', () => {
     it('does not round with a zero quotient', () => {
       expect(down(0, 5, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(down(22, 5, calculator)).toBe(4);
-    });
-    it('rounds down with a negative quotient below half', () => {
-      expect(down(-22, 5, calculator)).toBe(-5);
-    });
     it('rounds down with a positive half quotient', () => {
       expect(down(3, 2, calculator)).toBe(1);
     });
     it('rounds down with a negative half quotient', () => {
       expect(down(-3, 2, calculator)).toBe(-2);
     });
-    it('rounds down with a positive quotient above half', () => {
-      expect(down(24, 5, calculator)).toBe(4);
+    it('rounds down with any positive float', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 4 }), (a) => {
+          expect(down(a, 5, calculator)).toBe(0);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(down(-24, 5, calculator)).toBe(-5);
+    it('rounds down with any negative float', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -1 }), (a) => {
+          expect(down(a, 5, calculator)).toBe(-1);
+        })
+      );
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfAwayFromZero.test.ts
+++ b/packages/core/src/divide/__tests__/halfAwayFromZero.test.ts
@@ -1,4 +1,5 @@
 import { calculator } from '@dinero.js/calculator-number';
+import * as fc from 'fast-check';
 
 import { halfAwayFromZero } from '../halfAwayFromZero';
 
@@ -13,23 +14,39 @@ describe('halfAwayFromZero', () => {
     it('does not round with a zero quotient', () => {
       expect(halfAwayFromZero(0, 10, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(halfAwayFromZero(14, 10, calculator)).toBe(1);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(halfAwayFromZero(-14, 10, calculator)).toBe(-1);
-    });
     it('rounds to the nearest integer away from zero with a positive half quotient', () => {
       expect(halfAwayFromZero(15, 10, calculator)).toBe(2);
     });
     it('rounds to the nearest integer away from zero with a negative half quotient', () => {
       expect(halfAwayFromZero(-25, 10, calculator)).toBe(-3);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(halfAwayFromZero(16, 10, calculator)).toBe(2);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 6, max: 9 }), (a) => {
+          expect(halfAwayFromZero(a, 10, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(halfAwayFromZero(-16, 10, calculator)).toBe(-2);
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -9, max: -6 }), (a) => {
+          expect(halfAwayFromZero(a, 10, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 4 }), (a) => {
+          expect(halfAwayFromZero(a, 10, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -1 }), (a) => {
+          expect(halfAwayFromZero(a, 10, calculator)).toBe(-0);
+        })
+      );
     });
   });
   describe('non-decimal factors', () => {
@@ -42,23 +59,39 @@ describe('halfAwayFromZero', () => {
     it('does not round with a zero quotient', () => {
       expect(halfAwayFromZero(0, 5, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(halfAwayFromZero(22, 5, calculator)).toBe(4);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(halfAwayFromZero(-22, 5, calculator)).toBe(-4);
-    });
     it('rounds to the nearest integer away from zero with a positive half quotient', () => {
       expect(halfAwayFromZero(3, 2, calculator)).toBe(2);
     });
     it('rounds to the nearest integer away from zero with a negative half quotient', () => {
       expect(halfAwayFromZero(-5, 2, calculator)).toBe(-3);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(halfAwayFromZero(24, 5, calculator)).toBe(5);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 3, max: 4 }), (a) => {
+          expect(halfAwayFromZero(a, 5, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(halfAwayFromZero(-24, 5, calculator)).toBe(-5);
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -3 }), (a) => {
+          expect(halfAwayFromZero(a, 5, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 2 }), (a) => {
+          expect(halfAwayFromZero(a, 5, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -2, max: -1 }), (a) => {
+          expect(halfAwayFromZero(a, 5, calculator)).toBe(-0);
+        })
+      );
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfAwayFromZero.test.ts
+++ b/packages/core/src/divide/__tests__/halfAwayFromZero.test.ts
@@ -4,6 +4,12 @@ import { halfAwayFromZero } from '../halfAwayFromZero';
 
 describe('halfAwayFromZero', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfAwayFromZero(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfAwayFromZero(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfAwayFromZero(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('halfAwayFromZero', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfAwayFromZero(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfAwayFromZero(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfAwayFromZero(5, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfAwayFromZero(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfAwayFromZero(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfAwayFromZero(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfAwayFromZero(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfAwayFromZero(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfAwayFromZero(-5, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfAwayFromZero(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfAwayFromZero(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfAwayFromZero(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfAwayFromZero(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('halfAwayFromZero', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfAwayFromZero(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfAwayFromZero(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfAwayFromZero(3, 6, calculator)).toBe(1);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfAwayFromZero(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfAwayFromZero(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfAwayFromZero(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfAwayFromZero(-3, 6, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfAwayFromZero(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfAwayFromZero.test.ts
+++ b/packages/core/src/divide/__tests__/halfAwayFromZero.test.ts
@@ -4,11 +4,14 @@ import { halfAwayFromZero } from '../halfAwayFromZero';
 
 describe('halfAwayFromZero', () => {
   describe('decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfAwayFromZero(20, 10, calculator)).toBe(2);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfAwayFromZero(-20, 10, calculator)).toBe(-2);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfAwayFromZero(0, 10, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfAwayFromZero(14, 10, calculator)).toBe(1);
@@ -28,40 +31,16 @@ describe('halfAwayFromZero', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfAwayFromZero(-16, 10, calculator)).toBe(-2);
     });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfAwayFromZero(6, 10, calculator)).toBe(1);
-    });
-    it('rounds to 1 with a positive half quotient that is close to 0', () => {
-      expect(halfAwayFromZero(5, 10, calculator)).toBe(1);
-    });
-    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
-      expect(halfAwayFromZero(4, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfAwayFromZero(1, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfAwayFromZero(0, 10, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
-      expect(halfAwayFromZero(-1, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
-      expect(halfAwayFromZero(-4, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative half quotient that is close to 0', () => {
-      expect(halfAwayFromZero(-5, 10, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
-      expect(halfAwayFromZero(-6, 10, calculator)).toBe(-1);
-    });
   });
   describe('non-decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfAwayFromZero(20, 5, calculator)).toBe(4);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfAwayFromZero(-20, 5, calculator)).toBe(-4);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfAwayFromZero(0, 5, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfAwayFromZero(22, 5, calculator)).toBe(4);
@@ -80,27 +59,6 @@ describe('halfAwayFromZero', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfAwayFromZero(-24, 5, calculator)).toBe(-5);
-    });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfAwayFromZero(3, 5, calculator)).toBe(1);
-    });
-    it('rounds to 1 with a positive half quotient that is close to 0', () => {
-      expect(halfAwayFromZero(3, 6, calculator)).toBe(1);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfAwayFromZero(1, 5, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfAwayFromZero(0, 5, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
-      expect(halfAwayFromZero(-1, 5, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative half quotient that is close to 0', () => {
-      expect(halfAwayFromZero(-3, 6, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
-      expect(halfAwayFromZero(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfDown.test.ts
+++ b/packages/core/src/divide/__tests__/halfDown.test.ts
@@ -1,4 +1,5 @@
 import { calculator } from '@dinero.js/calculator-number';
+import * as fc from 'fast-check';
 
 import { halfDown } from '../halfDown';
 
@@ -13,23 +14,39 @@ describe('halfDown', () => {
     it('does not round with a zero quotient', () => {
       expect(halfDown(0, 10, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(halfDown(14, 10, calculator)).toBe(1);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(halfDown(-14, 10, calculator)).toBe(-1);
-    });
     it('rounds down with a positive half quotient', () => {
       expect(halfDown(15, 10, calculator)).toBe(1);
     });
     it('rounds down with a negative half quotient', () => {
       expect(halfDown(-15, 10, calculator)).toBe(-2);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(halfDown(16, 10, calculator)).toBe(2);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 6, max: 9 }), (a) => {
+          expect(halfDown(a, 10, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(halfDown(-16, 10, calculator)).toBe(-2);
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -9, max: -6 }), (a) => {
+          expect(halfDown(a, 10, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 4 }), (a) => {
+          expect(halfDown(a, 10, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -1 }), (a) => {
+          expect(halfDown(a, 10, calculator)).toBe(-0);
+        })
+      );
     });
   });
   describe('non-decimal factors', () => {
@@ -59,6 +76,34 @@ describe('halfDown', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfDown(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 3, max: 4 }), (a) => {
+          expect(halfDown(a, 5, calculator)).toBe(1);
+        })
+      );
+    });
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -3 }), (a) => {
+          expect(halfDown(a, 5, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 2 }), (a) => {
+          expect(halfDown(a, 5, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -2, max: -1 }), (a) => {
+          expect(halfDown(a, 5, calculator)).toBe(-0);
+        })
+      );
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfDown.test.ts
+++ b/packages/core/src/divide/__tests__/halfDown.test.ts
@@ -4,6 +4,12 @@ import { halfDown } from '../halfDown';
 
 describe('halfDown', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfDown(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfDown(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfDown(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('halfDown', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfDown(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfDown(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfDown(5, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfDown(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfDown(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfDown(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfDown(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfDown(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfDown(-5, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfDown(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfDown(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfDown(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfDown(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('halfDown', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfDown(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfDown(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfDown(3, 6, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfDown(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfDown(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfDown(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfDown(-3, 6, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfDown(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfDown.test.ts
+++ b/packages/core/src/divide/__tests__/halfDown.test.ts
@@ -4,11 +4,14 @@ import { halfDown } from '../halfDown';
 
 describe('halfDown', () => {
   describe('decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfDown(20, 10, calculator)).toBe(2);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfDown(-20, 10, calculator)).toBe(-2);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfDown(0, 10, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfDown(14, 10, calculator)).toBe(1);
@@ -28,40 +31,16 @@ describe('halfDown', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfDown(-16, 10, calculator)).toBe(-2);
     });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfDown(6, 10, calculator)).toBe(1);
-    });
-    it('rounds to 0 with a positive half quotient that is close to 0', () => {
-      expect(halfDown(5, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
-      expect(halfDown(4, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfDown(1, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfDown(0, 10, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
-      expect(halfDown(-1, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
-      expect(halfDown(-4, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative half quotient that is close to 0', () => {
-      expect(halfDown(-5, 10, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
-      expect(halfDown(-6, 10, calculator)).toBe(-1);
-    });
   });
   describe('non-decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfDown(20, 5, calculator)).toBe(4);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfDown(-20, 5, calculator)).toBe(-4);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfDown(0, 5, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfDown(22, 5, calculator)).toBe(4);
@@ -80,27 +59,6 @@ describe('halfDown', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfDown(-24, 5, calculator)).toBe(-5);
-    });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfDown(3, 5, calculator)).toBe(1);
-    });
-    it('rounds to 0 with a positive half quotient that is close to 0', () => {
-      expect(halfDown(3, 6, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfDown(1, 5, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfDown(0, 5, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
-      expect(halfDown(-1, 5, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative half quotient that is close to 0', () => {
-      expect(halfDown(-3, 6, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
-      expect(halfDown(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfEven.test.ts
+++ b/packages/core/src/divide/__tests__/halfEven.test.ts
@@ -4,11 +4,14 @@ import { halfEven } from '../halfEven';
 
 describe('halfEven', () => {
   describe('decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfEven(20, 10, calculator)).toBe(2);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfEven(-20, 10, calculator)).toBe(-2);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfEven(0, 10, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfEven(14, 10, calculator)).toBe(1);
@@ -31,40 +34,16 @@ describe('halfEven', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfEven(-16, 10, calculator)).toBe(-2);
     });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfEven(6, 10, calculator)).toBe(1);
-    });
-    it('rounds to 0 with a positive half quotient that is close to 0', () => {
-      expect(halfEven(5, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
-      expect(halfEven(4, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfEven(1, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfEven(0, 10, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
-      expect(halfEven(-1, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
-      expect(halfEven(-4, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative half quotient that is close to 0', () => {
-      expect(halfEven(-5, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
-      expect(halfEven(-6, 10, calculator)).toBe(-1);
-    });
   });
   describe('non-decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfEven(20, 5, calculator)).toBe(4);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfEven(-20, 5, calculator)).toBe(-4);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfEven(0, 5, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfEven(22, 5, calculator)).toBe(4);
@@ -86,27 +65,6 @@ describe('halfEven', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfEven(-24, 5, calculator)).toBe(-5);
-    });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfEven(3, 5, calculator)).toBe(1);
-    });
-    it('rounds to 0 with a positive half quotient that is close to 0', () => {
-      expect(halfEven(3, 6, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfEven(1, 5, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfEven(0, 5, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
-      expect(halfEven(-1, 5, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative half quotient that is close to 0', () => {
-      expect(halfEven(-3, 6, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
-      expect(halfEven(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfEven.test.ts
+++ b/packages/core/src/divide/__tests__/halfEven.test.ts
@@ -1,4 +1,5 @@
 import { calculator } from '@dinero.js/calculator-number';
+import * as fc from 'fast-check';
 
 import { halfEven } from '../halfEven';
 
@@ -13,12 +14,6 @@ describe('halfEven', () => {
     it('does not round with a zero quotient', () => {
       expect(halfEven(0, 10, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(halfEven(14, 10, calculator)).toBe(1);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(halfEven(-14, 10, calculator)).toBe(-1);
-    });
     it('rounds to nearest even integer with a positive half quotient rounding to an even integer', () => {
       expect(halfEven(15, 10, calculator)).toBe(2);
     });
@@ -28,11 +23,33 @@ describe('halfEven', () => {
     it('rounds to nearest even integer with a negative half quotient', () => {
       expect(halfEven(-25, 10, calculator)).toBe(-2);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(halfEven(16, 10, calculator)).toBe(2);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 6, max: 9 }), (a) => {
+          expect(halfEven(a, 10, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(halfEven(-16, 10, calculator)).toBe(-2);
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -9, max: -6 }), (a) => {
+          expect(halfEven(a, 10, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 4 }), (a) => {
+          expect(halfEven(a, 10, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -1 }), (a) => {
+          expect(halfEven(a, 10, calculator)).toBe(-0);
+        })
+      );
     });
   });
   describe('non-decimal factors', () => {
@@ -45,12 +62,6 @@ describe('halfEven', () => {
     it('does not round with a zero quotient', () => {
       expect(halfEven(0, 5, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(halfEven(22, 5, calculator)).toBe(4);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(halfEven(-22, 5, calculator)).toBe(-4);
-    });
     it('rounds to nearest even integer with a positive half quotient rounding to an even integer', () => {
       expect(halfEven(3, 2, calculator)).toBe(2);
     });
@@ -60,11 +71,33 @@ describe('halfEven', () => {
     it('rounds to nearest even integer with a negative half quotient', () => {
       expect(halfEven(-5, 2, calculator)).toBe(-2);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(halfEven(24, 5, calculator)).toBe(5);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 3, max: 4 }), (a) => {
+          expect(halfEven(a, 5, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(halfEven(-24, 5, calculator)).toBe(-5);
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -3 }), (a) => {
+          expect(halfEven(a, 5, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 2 }), (a) => {
+          expect(halfEven(a, 5, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -2, max: -1 }), (a) => {
+          expect(halfEven(a, 5, calculator)).toBe(-0);
+        })
+      );
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfEven.test.ts
+++ b/packages/core/src/divide/__tests__/halfEven.test.ts
@@ -4,6 +4,12 @@ import { halfEven } from '../halfEven';
 
 describe('halfEven', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfEven(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfEven(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfEven(14, 10, calculator)).toBe(1);
     });
@@ -25,8 +31,41 @@ describe('halfEven', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfEven(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfEven(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfEven(5, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfEven(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfEven(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfEven(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfEven(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfEven(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfEven(-5, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfEven(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfEven(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfEven(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfEven(22, 5, calculator)).toBe(4);
     });
@@ -47,6 +86,27 @@ describe('halfEven', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfEven(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfEven(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfEven(3, 6, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfEven(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfEven(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfEven(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfEven(-3, 6, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfEven(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfOdd.test.ts
+++ b/packages/core/src/divide/__tests__/halfOdd.test.ts
@@ -4,6 +4,12 @@ import { halfOdd } from '../halfOdd';
 
 describe('halfOdd', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfOdd(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfOdd(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfOdd(14, 10, calculator)).toBe(1);
     });
@@ -25,8 +31,41 @@ describe('halfOdd', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfOdd(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfOdd(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfOdd(5, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfOdd(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfOdd(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfOdd(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfOdd(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfOdd(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfOdd(-5, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfOdd(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfOdd(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfOdd(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfOdd(22, 5, calculator)).toBe(4);
     });
@@ -47,6 +86,27 @@ describe('halfOdd', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfOdd(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfOdd(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfOdd(3, 6, calculator)).toBe(1);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfOdd(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfOdd(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfOdd(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfOdd(-3, 6, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfOdd(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfOdd.test.ts
+++ b/packages/core/src/divide/__tests__/halfOdd.test.ts
@@ -4,11 +4,14 @@ import { halfOdd } from '../halfOdd';
 
 describe('halfOdd', () => {
   describe('decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfOdd(20, 10, calculator)).toBe(2);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfOdd(-20, 10, calculator)).toBe(-2);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfOdd(0, 10, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfOdd(14, 10, calculator)).toBe(1);
@@ -31,40 +34,16 @@ describe('halfOdd', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfOdd(-16, 10, calculator)).toBe(-2);
     });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfOdd(6, 10, calculator)).toBe(1);
-    });
-    it('rounds to 1 with a positive half quotient that is close to 0', () => {
-      expect(halfOdd(5, 10, calculator)).toBe(1);
-    });
-    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
-      expect(halfOdd(4, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfOdd(1, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfOdd(0, 10, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
-      expect(halfOdd(-1, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
-      expect(halfOdd(-4, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative half quotient that is close to 0', () => {
-      expect(halfOdd(-5, 10, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
-      expect(halfOdd(-6, 10, calculator)).toBe(-1);
-    });
   });
   describe('non-decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfOdd(20, 5, calculator)).toBe(4);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfOdd(-20, 5, calculator)).toBe(-4);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfOdd(0, 5, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfOdd(22, 5, calculator)).toBe(4);
@@ -86,27 +65,6 @@ describe('halfOdd', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfOdd(-24, 5, calculator)).toBe(-5);
-    });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfOdd(3, 5, calculator)).toBe(1);
-    });
-    it('rounds to 1 with a positive half quotient that is close to 0', () => {
-      expect(halfOdd(3, 6, calculator)).toBe(1);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfOdd(1, 5, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfOdd(0, 5, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
-      expect(halfOdd(-1, 5, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative half quotient that is close to 0', () => {
-      expect(halfOdd(-3, 6, calculator)).toBe(-1);
-    });
-    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
-      expect(halfOdd(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfOdd.test.ts
+++ b/packages/core/src/divide/__tests__/halfOdd.test.ts
@@ -1,4 +1,5 @@
 import { calculator } from '@dinero.js/calculator-number';
+import * as fc from 'fast-check';
 
 import { halfOdd } from '../halfOdd';
 
@@ -13,12 +14,6 @@ describe('halfOdd', () => {
     it('does not round with a zero quotient', () => {
       expect(halfOdd(0, 10, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(halfOdd(14, 10, calculator)).toBe(1);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(halfOdd(-14, 10, calculator)).toBe(-1);
-    });
     it('rounds to nearest odd integer with a positive half quotient rounding to an even integer', () => {
       expect(halfOdd(15, 10, calculator)).toBe(1);
     });
@@ -28,11 +23,33 @@ describe('halfOdd', () => {
     it('rounds to nearest odd integer with a negative half quotient', () => {
       expect(halfOdd(-25, 10, calculator)).toBe(-3);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(halfOdd(16, 10, calculator)).toBe(2);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 6, max: 9 }), (a) => {
+          expect(halfOdd(a, 10, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(halfOdd(-16, 10, calculator)).toBe(-2);
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -9, max: -6 }), (a) => {
+          expect(halfOdd(a, 10, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 4 }), (a) => {
+          expect(halfOdd(a, 10, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -1 }), (a) => {
+          expect(halfOdd(a, 10, calculator)).toBe(-0);
+        })
+      );
     });
   });
   describe('non-decimal factors', () => {
@@ -45,12 +62,6 @@ describe('halfOdd', () => {
     it('does not round with a zero quotient', () => {
       expect(halfOdd(0, 5, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(halfOdd(22, 5, calculator)).toBe(4);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(halfOdd(-22, 5, calculator)).toBe(-4);
-    });
     it('rounds to nearest odd integer with a positive half quotient rounding to an even integer', () => {
       expect(halfOdd(3, 2, calculator)).toBe(1);
     });
@@ -60,11 +71,33 @@ describe('halfOdd', () => {
     it('rounds to nearest odd integer with a negative half quotient', () => {
       expect(halfOdd(-5, 2, calculator)).toBe(-3);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(halfOdd(24, 5, calculator)).toBe(5);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 3, max: 4 }), (a) => {
+          expect(halfOdd(a, 5, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(halfOdd(-24, 5, calculator)).toBe(-5);
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -3 }), (a) => {
+          expect(halfOdd(a, 5, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 2 }), (a) => {
+          expect(halfOdd(a, 5, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -2, max: -1 }), (a) => {
+          expect(halfOdd(a, 5, calculator)).toBe(-0);
+        })
+      );
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfTowardsZero.test.ts
+++ b/packages/core/src/divide/__tests__/halfTowardsZero.test.ts
@@ -4,6 +4,12 @@ import { halfTowardsZero } from '../halfTowardsZero';
 
 describe('halfTowardsZero', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfTowardsZero(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfTowardsZero(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive float below half', () => {
       expect(halfTowardsZero(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('halfTowardsZero', () => {
     it('rounds down with a negative float above half', () => {
       expect(halfTowardsZero(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfTowardsZero(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfTowardsZero(5, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfTowardsZero(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfTowardsZero(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfTowardsZero(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfTowardsZero(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfTowardsZero(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfTowardsZero(-5, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfTowardsZero(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfTowardsZero(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfTowardsZero(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive float below half', () => {
       expect(halfTowardsZero(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('halfTowardsZero', () => {
     });
     it('rounds down with a negative float above half', () => {
       expect(halfTowardsZero(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfTowardsZero(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfTowardsZero(3, 6, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfTowardsZero(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfTowardsZero(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfTowardsZero(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfTowardsZero(-3, 6, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfTowardsZero(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfTowardsZero.test.ts
+++ b/packages/core/src/divide/__tests__/halfTowardsZero.test.ts
@@ -4,11 +4,14 @@ import { halfTowardsZero } from '../halfTowardsZero';
 
 describe('halfTowardsZero', () => {
   describe('decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfTowardsZero(20, 10, calculator)).toBe(2);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfTowardsZero(-20, 10, calculator)).toBe(-2);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfTowardsZero(0, 10, calculator)).toBe(0);
     });
     it('rounds down with a positive float below half', () => {
       expect(halfTowardsZero(14, 10, calculator)).toBe(1);
@@ -28,40 +31,16 @@ describe('halfTowardsZero', () => {
     it('rounds down with a negative float above half', () => {
       expect(halfTowardsZero(-16, 10, calculator)).toBe(-2);
     });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfTowardsZero(6, 10, calculator)).toBe(1);
-    });
-    it('rounds to 0 with a positive half quotient that is close to 0', () => {
-      expect(halfTowardsZero(5, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
-      expect(halfTowardsZero(4, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfTowardsZero(1, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfTowardsZero(0, 10, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
-      expect(halfTowardsZero(-1, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
-      expect(halfTowardsZero(-4, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative half quotient that is close to 0', () => {
-      expect(halfTowardsZero(-5, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
-      expect(halfTowardsZero(-6, 10, calculator)).toBe(-1);
-    });
   });
   describe('non-decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfTowardsZero(20, 5, calculator)).toBe(4);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfTowardsZero(-20, 5, calculator)).toBe(-4);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfTowardsZero(0, 5, calculator)).toBe(0);
     });
     it('rounds down with a positive float below half', () => {
       expect(halfTowardsZero(22, 5, calculator)).toBe(4);
@@ -80,27 +59,6 @@ describe('halfTowardsZero', () => {
     });
     it('rounds down with a negative float above half', () => {
       expect(halfTowardsZero(-24, 5, calculator)).toBe(-5);
-    });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfTowardsZero(3, 5, calculator)).toBe(1);
-    });
-    it('rounds to 0 with a positive half quotient that is close to 0', () => {
-      expect(halfTowardsZero(3, 6, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfTowardsZero(1, 5, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfTowardsZero(0, 5, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
-      expect(halfTowardsZero(-1, 5, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative half quotient that is close to 0', () => {
-      expect(halfTowardsZero(-3, 6, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
-      expect(halfTowardsZero(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfTowardsZero.test.ts
+++ b/packages/core/src/divide/__tests__/halfTowardsZero.test.ts
@@ -1,4 +1,5 @@
 import { calculator } from '@dinero.js/calculator-number';
+import * as fc from 'fast-check';
 
 import { halfTowardsZero } from '../halfTowardsZero';
 
@@ -13,23 +14,39 @@ describe('halfTowardsZero', () => {
     it('does not round with a zero quotient', () => {
       expect(halfTowardsZero(0, 10, calculator)).toBe(0);
     });
-    it('rounds down with a positive float below half', () => {
-      expect(halfTowardsZero(14, 10, calculator)).toBe(1);
-    });
-    it('rounds up with a negative float below half', () => {
-      expect(halfTowardsZero(-14, 10, calculator)).toBe(-1);
-    });
     it('rounds to the nearest integer towards zero with a positive half float', () => {
       expect(halfTowardsZero(15, 10, calculator)).toBe(1);
     });
     it('rounds to the nearest integer towards zero with a negative half float', () => {
       expect(halfTowardsZero(-25, 10, calculator)).toBe(-2);
     });
-    it('rounds up with a positive float above half', () => {
-      expect(halfTowardsZero(16, 10, calculator)).toBe(2);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 6, max: 9 }), (a) => {
+          expect(halfTowardsZero(a, 10, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative float above half', () => {
-      expect(halfTowardsZero(-16, 10, calculator)).toBe(-2);
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -9, max: -6 }), (a) => {
+          expect(halfTowardsZero(a, 10, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 4 }), (a) => {
+          expect(halfTowardsZero(a, 10, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -1 }), (a) => {
+          expect(halfTowardsZero(a, 10, calculator)).toBe(-0);
+        })
+      );
     });
   });
   describe('non-decimal factors', () => {
@@ -42,23 +59,39 @@ describe('halfTowardsZero', () => {
     it('does not round with a zero quotient', () => {
       expect(halfTowardsZero(0, 5, calculator)).toBe(0);
     });
-    it('rounds down with a positive float below half', () => {
-      expect(halfTowardsZero(22, 5, calculator)).toBe(4);
-    });
-    it('rounds up with a negative float below half', () => {
-      expect(halfTowardsZero(-22, 5, calculator)).toBe(-4);
-    });
     it('rounds to the nearest integer towards zero with a positive half float', () => {
       expect(halfTowardsZero(3, 2, calculator)).toBe(1);
     });
     it('rounds to the nearest integer towards zero with a negative half float', () => {
       expect(halfTowardsZero(-5, 2, calculator)).toBe(-2);
     });
-    it('rounds up with a positive float above half', () => {
-      expect(halfTowardsZero(24, 5, calculator)).toBe(5);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 3, max: 4 }), (a) => {
+          expect(halfTowardsZero(a, 5, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative float above half', () => {
-      expect(halfTowardsZero(-24, 5, calculator)).toBe(-5);
+    it('rounds down with any negative quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -3 }), (a) => {
+          expect(halfTowardsZero(a, 5, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 2 }), (a) => {
+          expect(halfTowardsZero(a, 5, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -2, max: -1 }), (a) => {
+          expect(halfTowardsZero(a, 5, calculator)).toBe(-0);
+        })
+      );
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfUp.test.ts
+++ b/packages/core/src/divide/__tests__/halfUp.test.ts
@@ -1,4 +1,5 @@
 import { calculator } from '@dinero.js/calculator-number';
+import * as fc from 'fast-check';
 
 import { halfUp } from '../halfUp';
 
@@ -13,23 +14,39 @@ describe('halfUp', () => {
     it('does not round with a zero quotient', () => {
       expect(halfUp(0, 10, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(halfUp(14, 10, calculator)).toBe(1);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(halfUp(-14, 10, calculator)).toBe(-1);
-    });
     it('rounds up with a positive half quotient', () => {
       expect(halfUp(15, 10, calculator)).toBe(2);
     });
     it('rounds up with a negative half quotient', () => {
       expect(halfUp(-15, 10, calculator)).toBe(-1);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(halfUp(16, 10, calculator)).toBe(2);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 6, max: 9 }), (a) => {
+          expect(halfUp(a, 10, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(halfUp(-16, 10, calculator)).toBe(-2);
+    it('rounds down with any negative float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -9, max: -6 }), (a) => {
+          expect(halfUp(a, 10, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 4 }), (a) => {
+          expect(halfUp(a, 10, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -1 }), (a) => {
+          expect(halfUp(a, 10, calculator)).toBe(-0);
+        })
+      );
     });
   });
   describe('non-decimal factors', () => {
@@ -42,23 +59,39 @@ describe('halfUp', () => {
     it('does not round with a zero quotient', () => {
       expect(halfUp(0, 5, calculator)).toBe(0);
     });
-    it('rounds down with a positive quotient below half', () => {
-      expect(halfUp(22, 5, calculator)).toBe(4);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(halfUp(-22, 5, calculator)).toBe(-4);
-    });
     it('rounds up with a positive half quotient', () => {
       expect(halfUp(3, 2, calculator)).toBe(2);
     });
     it('rounds up with a negative half quotient', () => {
       expect(halfUp(-3, 2, calculator)).toBe(-1);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(halfUp(24, 5, calculator)).toBe(5);
+    it('rounds up with any positive float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 3, max: 4 }), (a) => {
+          expect(halfUp(a, 5, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds down with a negative quotient above half', () => {
-      expect(halfUp(-24, 5, calculator)).toBe(-5);
+    it('rounds down with any negative float quotient above half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -3 }), (a) => {
+          expect(halfUp(a, 5, calculator)).toBe(-1);
+        })
+      );
+    });
+    it('rounds down with any positive float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 2 }), (a) => {
+          expect(halfUp(a, 5, calculator)).toBe(0);
+        })
+      );
+    });
+    it('rounds up with any negative float quotient below half', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -2, max: -1 }), (a) => {
+          expect(halfUp(a, 5, calculator)).toBe(-0);
+        })
+      );
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfUp.test.ts
+++ b/packages/core/src/divide/__tests__/halfUp.test.ts
@@ -4,11 +4,14 @@ import { halfUp } from '../halfUp';
 
 describe('halfUp', () => {
   describe('decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfUp(20, 10, calculator)).toBe(2);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfUp(-20, 10, calculator)).toBe(-2);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfUp(0, 10, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfUp(14, 10, calculator)).toBe(1);
@@ -28,40 +31,16 @@ describe('halfUp', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfUp(-16, 10, calculator)).toBe(-2);
     });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfUp(6, 10, calculator)).toBe(1);
-    });
-    it('rounds to 1 with a positive half quotient that is close to 0', () => {
-      expect(halfUp(5, 10, calculator)).toBe(1);
-    });
-    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
-      expect(halfUp(4, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfUp(1, 10, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfUp(0, 10, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
-      expect(halfUp(-1, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
-      expect(halfUp(-4, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative half quotient that is close to 0', () => {
-      expect(halfUp(-5, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
-      expect(halfUp(-6, 10, calculator)).toBe(-1);
-    });
   });
   describe('non-decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(halfUp(20, 5, calculator)).toBe(4);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(halfUp(-20, 5, calculator)).toBe(-4);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(halfUp(0, 5, calculator)).toBe(0);
     });
     it('rounds down with a positive quotient below half', () => {
       expect(halfUp(22, 5, calculator)).toBe(4);
@@ -80,27 +59,6 @@ describe('halfUp', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfUp(-24, 5, calculator)).toBe(-5);
-    });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(halfUp(3, 5, calculator)).toBe(1);
-    });
-    it('rounds to 1 with a positive half quotient that is close to 0', () => {
-      expect(halfUp(3, 6, calculator)).toBe(1);
-    });
-    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(halfUp(1, 5, calculator)).toBe(0);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(halfUp(0, 5, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
-      expect(halfUp(-1, 5, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative half quotient that is close to 0', () => {
-      expect(halfUp(-3, 6, calculator)).toBe(-0);
-    });
-    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
-      expect(halfUp(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfUp.test.ts
+++ b/packages/core/src/divide/__tests__/halfUp.test.ts
@@ -4,6 +4,12 @@ import { halfUp } from '../halfUp';
 
 describe('halfUp', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfUp(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfUp(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfUp(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('halfUp', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfUp(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfUp(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfUp(5, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfUp(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfUp(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfUp(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfUp(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfUp(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfUp(-5, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfUp(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfUp(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfUp(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfUp(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('halfUp', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfUp(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfUp(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfUp(3, 6, calculator)).toBe(1);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfUp(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfUp(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfUp(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfUp(-3, 6, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfUp(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/up.test.ts
+++ b/packages/core/src/divide/__tests__/up.test.ts
@@ -4,6 +4,12 @@ import { up } from '../up';
 
 describe('up', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(up(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(up(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds up with a positive quotient below half', () => {
       expect(up(14, 10, calculator)).toBe(2);
     });
@@ -22,8 +28,41 @@ describe('up', () => {
     it('rounds up with a negative quotient above half', () => {
       expect(up(-16, 10, calculator)).toBe(-1);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(up(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(up(5, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive quotient and below half that is close to 0', () => {
+      expect(up(4, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(up(1, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(up(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(up(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(up(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(up(-5, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient above half, that is close to 0', () => {
+      expect(up(-6, 10, calculator)).toBe(-0);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(up(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(up(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds up with a positive quotient below half', () => {
       expect(up(22, 5, calculator)).toBe(5);
     });
@@ -41,6 +80,27 @@ describe('up', () => {
     });
     it('rounds up with a negative quotient above half', () => {
       expect(up(-24, 5, calculator)).toBe(-4);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(up(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(up(3, 6, calculator)).toBe(1);
+    });
+    it('rounds to 1 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(up(1, 5, calculator)).toBe(1);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(up(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(up(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(up(-3, 6, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient above half that is close to 0', () => {
+      expect(up(-3, 5, calculator)).toBe(-0);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/up.test.ts
+++ b/packages/core/src/divide/__tests__/up.test.ts
@@ -1,4 +1,5 @@
 import { calculator } from '@dinero.js/calculator-number';
+import * as fc from 'fast-check';
 
 import { up } from '../up';
 
@@ -13,23 +14,25 @@ describe('up', () => {
     it('does not round with a zero quotient', () => {
       expect(up(0, 10, calculator)).toBe(0);
     });
-    it('rounds up with a positive quotient below half', () => {
-      expect(up(14, 10, calculator)).toBe(2);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(up(-14, 10, calculator)).toBe(-1);
-    });
     it('rounds up with a positive half quotient', () => {
       expect(up(15, 10, calculator)).toBe(2);
     });
     it('rounds up with a negative half quotient', () => {
       expect(up(-15, 10, calculator)).toBe(-1);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(up(16, 10, calculator)).toBe(2);
+    it('rounds up with any positive float quotient', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 9 }), (a) => {
+          expect(up(a, 10, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds up with a negative quotient above half', () => {
-      expect(up(-16, 10, calculator)).toBe(-1);
+    it('rounds up with any negative float quotient', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -9, max: -1 }), (a) => {
+          expect(up(a, 10, calculator)).toBe(-0);
+        })
+      );
     });
   });
   describe('non-decimal factors', () => {
@@ -42,23 +45,25 @@ describe('up', () => {
     it('does not round with a zero quotient', () => {
       expect(up(0, 5, calculator)).toBe(0);
     });
-    it('rounds up with a positive quotient below half', () => {
-      expect(up(22, 5, calculator)).toBe(5);
-    });
-    it('rounds up with a negative quotient below half', () => {
-      expect(up(-22, 5, calculator)).toBe(-4);
-    });
     it('rounds up with a positive half quotient', () => {
       expect(up(3, 2, calculator)).toBe(2);
     });
     it('rounds up with a negative half quotient', () => {
       expect(up(-3, 2, calculator)).toBe(-1);
     });
-    it('rounds up with a positive quotient above half', () => {
-      expect(up(24, 5, calculator)).toBe(5);
+    it('rounds up with any positive float quotient', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 4 }), (a) => {
+          expect(up(a, 5, calculator)).toBe(1);
+        })
+      );
     });
-    it('rounds up with a negative quotient above half', () => {
-      expect(up(-24, 5, calculator)).toBe(-4);
+    it('rounds up with any negative float quotient', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -4, max: -1 }), (a) => {
+          expect(up(a, 5, calculator)).toBe(-0);
+        })
+      );
     });
   });
 });

--- a/packages/core/src/divide/__tests__/up.test.ts
+++ b/packages/core/src/divide/__tests__/up.test.ts
@@ -4,11 +4,14 @@ import { up } from '../up';
 
 describe('up', () => {
   describe('decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(up(20, 10, calculator)).toBe(2);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(up(-20, 10, calculator)).toBe(-2);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(up(0, 10, calculator)).toBe(0);
     });
     it('rounds up with a positive quotient below half', () => {
       expect(up(14, 10, calculator)).toBe(2);
@@ -28,40 +31,16 @@ describe('up', () => {
     it('rounds up with a negative quotient above half', () => {
       expect(up(-16, 10, calculator)).toBe(-1);
     });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(up(6, 10, calculator)).toBe(1);
-    });
-    it('rounds to 1 with a positive half quotient that is close to 0', () => {
-      expect(up(5, 10, calculator)).toBe(1);
-    });
-    it('rounds to 1 with a positive quotient and below half that is close to 0', () => {
-      expect(up(4, 10, calculator)).toBe(1);
-    });
-    it('rounds to 1 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(up(1, 10, calculator)).toBe(1);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(up(0, 10, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
-      expect(up(-1, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
-      expect(up(-4, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative half quotient that is close to 0', () => {
-      expect(up(-5, 10, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative quotient above half, that is close to 0', () => {
-      expect(up(-6, 10, calculator)).toBe(-0);
-    });
   });
   describe('non-decimal factors', () => {
-    it('should not round positive integer quotients', () => {
+    it('does not round with a positive integer quotient', () => {
       expect(up(20, 5, calculator)).toBe(4);
     });
-    it('should not round negative integer quotients', () => {
+    it('does not round with a negative integer quotient', () => {
       expect(up(-20, 5, calculator)).toBe(-4);
+    });
+    it('does not round with a zero quotient', () => {
+      expect(up(0, 5, calculator)).toBe(0);
     });
     it('rounds up with a positive quotient below half', () => {
       expect(up(22, 5, calculator)).toBe(5);
@@ -80,27 +59,6 @@ describe('up', () => {
     });
     it('rounds up with a negative quotient above half', () => {
       expect(up(-24, 5, calculator)).toBe(-4);
-    });
-    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
-      expect(up(3, 5, calculator)).toBe(1);
-    });
-    it('rounds to 1 with a positive half quotient that is close to 0', () => {
-      expect(up(3, 6, calculator)).toBe(1);
-    });
-    it('rounds to 1 with amount 1 and a positive quotient below half that is close to 0', () => {
-      expect(up(1, 5, calculator)).toBe(1);
-    });
-    it('rounds to 0 when quotient is 0', () => {
-      expect(up(0, 5, calculator)).toBe(0);
-    });
-    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
-      expect(up(-1, 5, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative half quotient that is close to 0', () => {
-      expect(up(-3, 6, calculator)).toBe(-0);
-    });
-    it('rounds to -0 with a negative quotient above half that is close to 0', () => {
-      expect(up(-3, 5, calculator)).toBe(-0);
     });
   });
 });

--- a/packages/core/src/divide/down.ts
+++ b/packages/core/src/divide/down.ts
@@ -1,16 +1,28 @@
 import type { DivideOperation } from '..';
-import { equal, greaterThanOrEqual } from '../utils';
+import { equal, greaterThan } from '../utils';
 
+/**
+ * Divide and round down.
+ *
+ * Rounding down happens whenever the quotient is not an integer.
+ *
+ * @param amount - The amount to divide.
+ * @param factor - The factor to divide by.
+ * @param calculator - The calculator to use.
+ *
+ * @returns The rounded amount.
+ */
 export const down: DivideOperation = (amount, factor, calculator) => {
-  const greaterThanOrEqualFn = greaterThanOrEqual(calculator);
+  const greaterThanFn = greaterThan(calculator);
   const equalFn = equal(calculator);
 
   const zero = calculator.zero();
-  const isPositive = greaterThanOrEqualFn(amount, zero);
+  const isPositive = greaterThanFn(amount, zero);
   const quotient = calculator.integerDivide(amount, factor);
   const remainder = calculator.modulo(amount, factor);
+  const isInteger = equalFn(remainder, zero);
 
-  if (isPositive || equalFn(remainder, zero)) {
+  if (isPositive || isInteger) {
     return quotient;
   }
 

--- a/packages/core/src/divide/down.ts
+++ b/packages/core/src/divide/down.ts
@@ -1,14 +1,16 @@
 import type { DivideOperation } from '..';
-import { greaterThanOrEqual } from '../utils';
+import { equal, greaterThanOrEqual } from '../utils';
 
 export const down: DivideOperation = (amount, factor, calculator) => {
   const greaterThanOrEqualFn = greaterThanOrEqual(calculator);
+  const equalFn = equal(calculator);
 
   const zero = calculator.zero();
   const isPositive = greaterThanOrEqualFn(amount, zero);
   const quotient = calculator.integerDivide(amount, factor);
+  const remainder = calculator.modulo(amount, factor);
 
-  if (isPositive) {
+  if (isPositive || equalFn(remainder, zero)) {
     return quotient;
   }
 

--- a/packages/core/src/divide/halfAwayFromZero.ts
+++ b/packages/core/src/divide/halfAwayFromZero.ts
@@ -3,6 +3,16 @@ import { sign, isHalf, absolute } from '../utils';
 
 import { halfUp, up } from '.';
 
+/**
+ * Divide and round towards "nearest neighbor" unless both neighbors are
+ * equidistant, in which case round away from zero.
+ *
+ * @param amount - The amount to divide.
+ * @param factor - The factor to divide by.
+ * @param calculator - The calculator to use.
+ *
+ * @returns The rounded amount.
+ */
 export const halfAwayFromZero: DivideOperation = (
   amount,
   factor,

--- a/packages/core/src/divide/halfDown.ts
+++ b/packages/core/src/divide/halfDown.ts
@@ -3,6 +3,21 @@ import { isHalf } from '../utils';
 
 import { down, halfUp } from '.';
 
+/**
+ * Divide and round towards "nearest neighbor" unless both neighbors are
+ * equidistant, in which case round down.
+ *
+ * Rounding down happens when:
+ * - The quotient is half (e.g., -1.5, 1.5).
+ * - The quotient is positive and less than half (e.g., 1.4).
+ * - The quotient is negative and greater than half (e.g., -1.6).
+ *
+ * @param amount - The amount to divide.
+ * @param factor - The factor to divide by.
+ * @param calculator - The calculator to use.
+ *
+ * @returns The rounded amount.
+ */
 export const halfDown: DivideOperation = (amount, factor, calculator) => {
   const isHalfFn = isHalf(calculator);
 

--- a/packages/core/src/divide/halfEven.ts
+++ b/packages/core/src/divide/halfEven.ts
@@ -3,6 +3,16 @@ import { isEven, isHalf } from '../utils';
 
 import { halfUp } from '.';
 
+/**
+ * Divide and round towards "nearest neighbor" unless both neighbors are
+ * equidistant, in which case round to the nearest even integer.
+ *
+ * @param amount - The amount to divide.
+ * @param factor - The factor to divide by.
+ * @param calculator - The calculator to use.
+ *
+ * @returns The rounded amount.
+ */
 export const halfEven: DivideOperation = (amount, factor, calculator) => {
   const isEvenFn = isEven(calculator);
   const isHalfFn = isHalf(calculator);

--- a/packages/core/src/divide/halfOdd.ts
+++ b/packages/core/src/divide/halfOdd.ts
@@ -3,6 +3,16 @@ import { isEven, isHalf } from '../utils';
 
 import { halfUp } from '.';
 
+/**
+ * Divide and round towards "nearest neighbor" unless both neighbors are
+ * equidistant, in which case round to the nearest odd integer.
+ *
+ * @param amount - The amount to divide.
+ * @param factor - The factor to divide by.
+ * @param calculator - The calculator to use.
+ *
+ * @returns The rounded amount.
+ */
 export const halfOdd: DivideOperation = (amount, factor, calculator) => {
   const isEvenFn = isEven(calculator);
   const isHalfFn = isHalf(calculator);

--- a/packages/core/src/divide/halfTowardsZero.ts
+++ b/packages/core/src/divide/halfTowardsZero.ts
@@ -3,6 +3,16 @@ import { sign, isHalf, absolute } from '../utils';
 
 import { halfUp, down } from '.';
 
+/**
+ * Divide and round towards "nearest neighbor" unless both neighbors are
+ * equidistant, in which case round towards zero.
+ *
+ * @param amount - The amount to divide.
+ * @param factor - The factor to divide by.
+ * @param calculator - The calculator to use.
+ *
+ * @returns The rounded amount.
+ */
 export const halfTowardsZero: DivideOperation = (
   amount,
   factor,

--- a/packages/core/src/divide/halfUp.ts
+++ b/packages/core/src/divide/halfUp.ts
@@ -1,5 +1,5 @@
 import type { DivideOperation } from '..';
-import { greaterThan, isHalf, absolute } from '../utils';
+import { absolute, greaterThan, isHalf } from '../utils';
 
 import { down, up } from '.';
 
@@ -12,12 +12,20 @@ export const halfUp: DivideOperation = (amount, factor, calculator) => {
   const remainder = absoluteFn(calculator.modulo(amount, factor));
   const difference = calculator.subtract(factor, remainder);
   const isLessThanHalf = greaterThanFn(difference, remainder);
-  const isPositive = greaterThanFn(amount, calculator.increment(zero));
+  const isPositive = greaterThanFn(amount, zero);
+
+  // Round up in these three cases:
+  // (1) the quotient is half:
+  //   e.g. ... -2.5,  -1.5,  -0.5,  0.5,  1.5,  2.5 ...
+  // (2) the quotient is positive, and greater than half:
+  //   e.g.                          0.51, 1.51, 2.51 ...
+  // (3) the quotient is negative, and less than half:
+  //   e.g. ... -2.49, -1.49, -0.49
 
   if (
     isHalfFn(amount, factor) ||
-    (isLessThanHalf && !isPositive) ||
-    (!isLessThanHalf && isPositive)
+    (isPositive && !isLessThanHalf) ||
+    (!isPositive && isLessThanHalf)
   ) {
     return up(amount, factor, calculator);
   }

--- a/packages/core/src/divide/halfUp.ts
+++ b/packages/core/src/divide/halfUp.ts
@@ -3,6 +3,21 @@ import { absolute, greaterThan, isHalf } from '../utils';
 
 import { down, up } from '.';
 
+/**
+ * Divide and round towards "nearest neighbor" unless both neighbors are
+ * equidistant, in which case round up.
+ *
+ * Rounding up happens when:
+ * - The quotient is half (e.g., -1.5, 1.5).
+ * - The quotient is positive and greater than half (e.g., 1.6).
+ * - The quotient is negative and less than half (e.g., -1.4).
+ *
+ * @param amount - The amount to divide.
+ * @param factor - The factor to divide by.
+ * @param calculator - The calculator to use.
+ *
+ * @returns The rounded amount.
+ */
 export const halfUp: DivideOperation = (amount, factor, calculator) => {
   const greaterThanFn = greaterThan(calculator);
   const isHalfFn = isHalf(calculator);
@@ -13,14 +28,6 @@ export const halfUp: DivideOperation = (amount, factor, calculator) => {
   const difference = calculator.subtract(factor, remainder);
   const isLessThanHalf = greaterThanFn(difference, remainder);
   const isPositive = greaterThanFn(amount, zero);
-
-  // Round up in these three cases:
-  // (1) the quotient is half:
-  //   e.g. ... -2.5,  -1.5,  -0.5,  0.5,  1.5,  2.5 ...
-  // (2) the quotient is positive, and greater than half:
-  //   e.g.                          0.51, 1.51, 2.51 ...
-  // (3) the quotient is negative, and less than half:
-  //   e.g. ... -2.49, -1.49, -0.49
 
   if (
     isHalfFn(amount, factor) ||

--- a/packages/core/src/divide/up.ts
+++ b/packages/core/src/divide/up.ts
@@ -1,6 +1,17 @@
 import type { DivideOperation } from '..';
 import { equal, greaterThan } from '../utils';
 
+/**
+ * Divide and round up.
+ *
+ * Rounding up happens whenever the quotient is not an integer.
+ *
+ * @param amount - The amount to divide.
+ * @param factor - The factor to divide by.
+ * @param calculator - The calculator to use.
+ *
+ * @returns The rounded amount.
+ */
 export const up: DivideOperation = (amount, factor, calculator) => {
   const greaterThanFn = greaterThan(calculator);
   const equalFn = equal(calculator);
@@ -9,8 +20,9 @@ export const up: DivideOperation = (amount, factor, calculator) => {
   const isPositive = greaterThanFn(amount, zero);
   const quotient = calculator.integerDivide(amount, factor);
   const remainder = calculator.modulo(amount, factor);
+  const isInteger = equalFn(remainder, zero);
 
-  if (!equalFn(remainder, zero) && isPositive) {
+  if (!isInteger && isPositive) {
     return calculator.increment(quotient);
   }
 

--- a/packages/core/src/divide/up.ts
+++ b/packages/core/src/divide/up.ts
@@ -1,14 +1,16 @@
 import type { DivideOperation } from '..';
-import { greaterThanOrEqual } from '../utils';
+import { equal, greaterThan } from '../utils';
 
 export const up: DivideOperation = (amount, factor, calculator) => {
-  const greaterThanOrEqualFn = greaterThanOrEqual(calculator);
+  const greaterThanFn = greaterThan(calculator);
+  const equalFn = equal(calculator);
 
   const zero = calculator.zero();
-  const isPositive = greaterThanOrEqualFn(amount, zero);
+  const isPositive = greaterThanFn(amount, zero);
   const quotient = calculator.integerDivide(amount, factor);
+  const remainder = calculator.modulo(amount, factor);
 
-  if (isPositive) {
+  if (!equalFn(remainder, zero) && isPositive) {
     return calculator.increment(quotient);
   }
 

--- a/packages/dinero.js/src/api/__tests__/multiply.test.ts
+++ b/packages/dinero.js/src/api/__tests__/multiply.test.ts
@@ -17,10 +17,27 @@ describe('multiply', () => {
     it('multiplies positive Dinero objects', () => {
       const d = dinero({ amount: 400, currency: USD });
 
-      const snapshot = toSnapshot(multiply(d, 4));
-
-      expect(snapshot).toEqual({
+      expect(toSnapshot(multiply(d, 4))).toEqual({
         amount: 1600,
+        scale: 2,
+        currency: USD,
+      });
+      expect(toSnapshot(multiply(d, -1))).toEqual({
+        amount: -400,
+        scale: 2,
+        currency: USD,
+      });
+    });
+    it('multiplies negative Dinero objects', () => {
+      const d = dinero({ amount: -400, currency: USD });
+
+      expect(toSnapshot(multiply(d, 4))).toEqual({
+        amount: -1600,
+        scale: 2,
+        currency: USD,
+      });
+      expect(toSnapshot(multiply(d, 1))).toEqual({
+        amount: -400,
         scale: 2,
         currency: USD,
       });
@@ -44,10 +61,27 @@ describe('multiply', () => {
     it('multiplies positive Dinero objects', () => {
       const d = dinero({ amount: 400n, currency: bigintUSD });
 
-      const snapshot = toSnapshot(multiply(d, 4n));
-
-      expect(snapshot).toEqual({
+      expect(toSnapshot(multiply(d, 4n))).toEqual({
         amount: 1600n,
+        scale: 2n,
+        currency: bigintUSD,
+      });
+      expect(toSnapshot(multiply(d, -1n))).toEqual({
+        amount: -400n,
+        scale: 2n,
+        currency: bigintUSD,
+      });
+    });
+    it('multiplies negative Dinero objects', () => {
+      const d = dinero({ amount: -400n, currency: bigintUSD });
+
+      expect(toSnapshot(multiply(d, 4n))).toEqual({
+        amount: -1600n,
+        scale: 2n,
+        currency: bigintUSD,
+      });
+      expect(toSnapshot(multiply(d, 1n))).toEqual({
+        amount: -400n,
         scale: 2n,
         currency: bigintUSD,
       });
@@ -71,10 +105,27 @@ describe('multiply', () => {
     it('multiplies positive Dinero objects', () => {
       const d = dinero({ amount: new Big(400), currency: bigjsUSD });
 
-      const snapshot = toSnapshot(multiply(d, new Big(4)));
-
-      expect(snapshot).toEqual({
+      expect(toSnapshot(multiply(d, new Big(4)))).toEqual({
         amount: new Big(1600),
+        scale: new Big(2),
+        currency: bigjsUSD,
+      });
+      expect(toSnapshot(multiply(d, new Big(-1)))).toEqual({
+        amount: new Big(-400),
+        scale: new Big(2),
+        currency: bigjsUSD,
+      });
+    });
+    it('multiplies negative Dinero objects', () => {
+      const d = dinero({ amount: new Big(-400), currency: bigjsUSD });
+
+      expect(toSnapshot(multiply(d, new Big(4)))).toEqual({
+        amount: new Big(-1600),
+        scale: new Big(2),
+        currency: bigjsUSD,
+      });
+      expect(toSnapshot(multiply(d, new Big(1)))).toEqual({
+        amount: new Big(-400),
         scale: new Big(2),
         currency: bigjsUSD,
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4928,6 +4928,13 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
+fast-check@3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-3.6.3.tgz#9adb8161390c4a6a84c0f3ed333b15e1c7292f8a"
+  integrity sha512-5+ovrjQLUa+F9RbRcW7A++K+olKy2mNgYNfFmXSzQOAQ/Fuit12F1UI8z5Bic9YgRkUAQqXSkFUAAs7xohbvvg==
+  dependencies:
+    pure-rand "^6.0.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -8423,6 +8430,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pure-rand@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.0.tgz#701996ceefa253507923a0e864c17ab421c04a7c"
+  integrity sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==
 
 purgecss@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
up/down - Functions should not round integer results.

up - up should only round positive numbers, 0 is not a positive number.

halfUp - halfUp was incorrectly rounding numbers in the [0,1) range due to the incorrect definition of isPositive.

Fixes #710
Fixes #713

Written by throwing tests at the wall and making them pass, would appreciate if someone could review their correctness.

In the rounding functions, is it necessary to handle the case where factor is negative? If so, the definition of isPositive in some of the functions may not handle this case.

From a big picture going to beta POV, some of these rounding functions are really obscure (e.g. halfOdd) and have little practical application. They also feel non-trivial to get right, do we really need all of them?

Also, rounding to -0 is correct but surprising, should something be done here?