### PR TITLE
test(toDecimal): issue Dinero<Big> objects with large scale

### DIFF
--- a/packages/dinero.js/src/api/__tests__/toDecimal.test.ts
+++ b/packages/dinero.js/src/api/__tests__/toDecimal.test.ts
@@ -1,5 +1,5 @@
 import { MGA, USD } from '@dinero.js/currencies';
-import Big from 'big.js';
+import { Big } from 'big.js';
 import {
   castToBigintCurrency,
   castToBigjsCurrency,
@@ -188,6 +188,15 @@ describe('toDecimal', () => {
         });
 
         expect(toDecimal(d)).toEqual('10000000000000000.50');
+      });
+      it('returns the amount in decimal format with large integers and large scale', () => {
+        const d = dinero({
+          amount: new Big('10000000000000000000000000000050'),
+          scale: new Big(22),
+          currency: bigjsUSD,
+        });
+
+        expect(toDecimal(d)).toBe('1000000000.0000000000000000000050');
       });
       it('returns the amount in decimal format based on a custom scale', () => {
         const d = dinero({

--- a/test/utils/createBigjsDinero.ts
+++ b/test/utils/createBigjsDinero.ts
@@ -1,4 +1,4 @@
-import Big from 'big.js';
+import { Big } from 'big.js';
 
 import { createDinero } from 'dinero.js';
 import type { DineroOptions, ComparisonOperator } from 'dinero.js';
@@ -15,6 +15,12 @@ const dinero = createDinero({
     power: (a, b) => a.pow(Number(b)),
     subtract: (a, b) => a.minus(b),
     zero: () => new Big(0),
+  },
+  formatter: {
+    // @ts-expect-error
+    toNumber: (v) => v.toNumber(),
+    // @ts-expect-error
+    toString: (v) => v.toFixed(),
   },
 });
 


### PR DESCRIPTION
This pull request resolves issue #716. The the default `formatter` from `createDinero` didn't stringify `Big.js` values with a large scale correctly.

There is still a question about the function signatures of the `Formatter`. I created PR #725 to discuss and correct this issue.