### PR TITLE
feat(createDinero): make formatter a required parameter

### DIFF
--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -65,12 +65,12 @@ rates: Rates<TAmount>
 ];
 
 // @public (undocumented)
-export function createDinero<TAmount>({ calculator, onCreate, formatter, }: CreateDineroOptions<TAmount>): ({ amount, currency: { code, base, exponent }, scale, }: DineroOptions<TAmount>) => Dinero<TAmount>;
+export function createDinero<TAmount>({ calculator, formatter, onCreate, }: CreateDineroOptions<TAmount>): ({ amount, currency: { code, base, exponent }, scale, }: DineroOptions<TAmount>) => Dinero<TAmount>;
 
 // @public (undocumented)
 export type CreateDineroOptions<TAmount> = {
     readonly calculator: Calculator<TAmount>;
-    readonly formatter?: Formatter<TAmount>;
+    readonly formatter: Formatter<TAmount>;
     readonly onCreate?: (options: DineroOptions<TAmount>) => void;
 };
 
@@ -116,8 +116,8 @@ comparator: Dinero<TAmount>
 
 // @public (undocumented)
 export type Formatter<TAmount> = {
-    readonly toNumber: (value?: TAmount) => number;
-    readonly toString: (value?: TAmount) => string;
+    readonly toNumber: (value: TAmount) => number;
+    readonly toString: (value: TAmount) => string;
 };
 
 // @public (undocumented)

--- a/packages/core/src/helpers/createDinero.ts
+++ b/packages/core/src/helpers/createDinero.ts
@@ -3,17 +3,14 @@ import type { Calculator, Dinero, DineroOptions, Formatter } from '../types';
 
 export type CreateDineroOptions<TAmount> = {
   readonly calculator: Calculator<TAmount>;
-  readonly formatter?: Formatter<TAmount>;
+  readonly formatter: Formatter<TAmount>;
   readonly onCreate?: (options: DineroOptions<TAmount>) => void;
 };
 
 export function createDinero<TAmount>({
   calculator,
+  formatter,
   onCreate,
-  formatter = {
-    toNumber: Number,
-    toString: String,
-  },
 }: CreateDineroOptions<TAmount>) {
   return function dinero({
     amount,

--- a/packages/core/src/types/Formatter.ts
+++ b/packages/core/src/types/Formatter.ts
@@ -1,4 +1,4 @@
 export type Formatter<TAmount> = {
-  readonly toNumber: (value?: TAmount) => number;
-  readonly toString: (value?: TAmount) => string;
+  readonly toNumber: (value: TAmount) => number;
+  readonly toString: (value: TAmount) => string;
 };

--- a/packages/dinero.js/src/dinero.ts
+++ b/packages/dinero.js/src/dinero.ts
@@ -20,6 +20,10 @@ import {
  */
 export const dinero = createDinero({
   calculator,
+  formatter: {
+    toNumber: Number,
+    toString: String,
+  },
   onCreate({ amount, scale }) {
     assert(Number.isInteger(amount), INVALID_AMOUNT_MESSAGE);
     assert(Number.isInteger(scale), INVALID_SCALE_MESSAGE);

--- a/test/utils/createBigintDinero.ts
+++ b/test/utils/createBigintDinero.ts
@@ -2,7 +2,13 @@ import { calculator } from '@dinero.js/calculator-bigint';
 import { createDinero } from 'dinero.js';
 import type { DineroOptions } from 'dinero.js';
 
-const dinero = createDinero({ calculator });
+const dinero = createDinero({
+  calculator,
+  formatter: {
+    toNumber: Number,
+    toString: String,
+  },
+});
 
 export function createBigintDinero(options: DineroOptions<bigint>) {
   return dinero(options);

--- a/test/utils/createBigjsDinero.ts
+++ b/test/utils/createBigjsDinero.ts
@@ -1,4 +1,4 @@
-import Big from 'big.js';
+import { Big } from 'big.js';
 
 import { createDinero } from 'dinero.js';
 import type { DineroOptions, ComparisonOperator } from 'dinero.js';
@@ -15,6 +15,10 @@ const dinero = createDinero({
     power: (a, b) => a.pow(Number(b)),
     subtract: (a, b) => a.minus(b),
     zero: () => new Big(0),
+  },
+  formatter: {
+    toNumber: (v) => v.toNumber(),
+    toString: (v) => v.toFixed(),
   },
 });
 


### PR DESCRIPTION
After diving into #716, I discovered that the `value` parameters of the `Formatter` functions were defined as possibly `undefined` which I don't believe is correct. This PR defines them as strictly `TAmount`.

It also makes the `formatter` parameter of `createDinero` required and removes the default argument. It's a high probable that any new implementation of `dinero` factories will need to define their own formatters, and that the default will actually cause incorrect values.