### PR TITLE
test: fix test/tsconfig.json extends property

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.test",
+  "extends": "../tsconfig",
   "compilerOptions": {
     "composite": true
   },


### PR DESCRIPTION
The `test/tsconfig.json` extended a nonexistent `tsconfig.test`. It now extends the root `tsconfig.json`.