### PR TITLE
fix(isPositive): return `false` with zero

### DIFF
--- a/packages/core/src/api/isPositive.ts
+++ b/packages/core/src/api/isPositive.ts
@@ -1,16 +1,16 @@
 import type { Calculator, Dinero } from '../types';
-import { greaterThanOrEqual } from '../utils';
+import { greaterThan } from '../utils';
 
 export type IsPositiveParams<TAmount> = readonly [
   dineroObject: Dinero<TAmount>
 ];
 
 export function isPositive<TAmount>(calculator: Calculator<TAmount>) {
-  const greaterThanOrEqualFn = greaterThanOrEqual(calculator);
+  const greaterThanFn = greaterThan(calculator);
 
   return function _isPositive(...[dineroObject]: IsPositiveParams<TAmount>) {
     const { amount } = dineroObject.toJSON();
 
-    return greaterThanOrEqualFn(amount, calculator.zero());
+    return greaterThanFn(amount, calculator.zero());
   };
 }

--- a/packages/dinero.js/src/api/__tests__/isNegative.test.ts
+++ b/packages/dinero.js/src/api/__tests__/isNegative.test.ts
@@ -25,9 +25,11 @@ describe('isNegative', () => {
       expect(isNegative(d)).toBe(false);
     });
     it('returns false when amount is equal to 0', () => {
-      const d = dinero({ amount: 0, currency: USD });
+      const d1 = dinero({ amount: 0, currency: USD });
+      const d2 = dinero({ amount: -0, currency: USD });
 
-      expect(isNegative(d)).toBe(false);
+      expect(isNegative(d1)).toBe(false);
+      expect(isNegative(d2)).toBe(false);
     });
   });
   describe('bigint', () => {
@@ -45,9 +47,11 @@ describe('isNegative', () => {
       expect(isNegative(d)).toBe(false);
     });
     it('returns false when amount is equal to 0', () => {
-      const d = dinero({ amount: 0n, currency: bigintUSD });
+      const d1 = dinero({ amount: 0n, currency: bigintUSD });
+      const d2 = dinero({ amount: -0n, currency: bigintUSD });
 
-      expect(isNegative(d)).toBe(false);
+      expect(isNegative(d1)).toBe(false);
+      expect(isNegative(d2)).toBe(false);
     });
   });
   describe('Big.js', () => {
@@ -65,9 +69,11 @@ describe('isNegative', () => {
       expect(isNegative(d)).toBe(false);
     });
     it('returns false when amount is equal to 0', () => {
-      const d = dinero({ amount: new Big(0), currency: bigjsUSD });
+      const d1 = dinero({ amount: new Big(0), currency: bigjsUSD });
+      const d2 = dinero({ amount: new Big(-0), currency: bigjsUSD });
 
-      expect(isNegative(d)).toBe(false);
+      expect(isNegative(d1)).toBe(false);
+      expect(isNegative(d2)).toBe(false);
     });
   });
 });

--- a/packages/dinero.js/src/api/__tests__/isPositive.test.ts
+++ b/packages/dinero.js/src/api/__tests__/isPositive.test.ts
@@ -24,10 +24,12 @@ describe('isPositive', () => {
 
       expect(isPositive(d)).toBe(true);
     });
-    it('returns true when amount is equal to 0', () => {
-      const d = dinero({ amount: 0, currency: USD });
+    it('returns false when amount is equal to 0', () => {
+      const d1 = dinero({ amount: 0, currency: USD });
+      const d2 = dinero({ amount: -0, currency: USD });
 
-      expect(isPositive(d)).toBe(true);
+      expect(isPositive(d1)).toBe(false);
+      expect(isPositive(d2)).toBe(false);
     });
   });
   describe('bigint', () => {
@@ -44,10 +46,12 @@ describe('isPositive', () => {
 
       expect(isPositive(d)).toBe(true);
     });
-    it('returns true when amount is equal to 0', () => {
-      const d = dinero({ amount: 0n, currency: bigintUSD });
+    it('returns false when amount is equal to 0', () => {
+      const d1 = dinero({ amount: 0n, currency: bigintUSD });
+      const d2 = dinero({ amount: -0n, currency: bigintUSD });
 
-      expect(isPositive(d)).toBe(true);
+      expect(isPositive(d1)).toBe(false);
+      expect(isPositive(d2)).toBe(false);
     });
   });
   describe('Big.js', () => {
@@ -64,10 +68,12 @@ describe('isPositive', () => {
 
       expect(isPositive(d)).toBe(true);
     });
-    it('returns true when amount is equal to 0', () => {
-      const d = dinero({ amount: new Big(0), currency: bigjsUSD });
+    it('returns false when amount is equal to 0', () => {
+      const d1 = dinero({ amount: new Big(0), currency: bigjsUSD });
+      const d2 = dinero({ amount: new Big(-0), currency: bigjsUSD });
 
-      expect(isPositive(d)).toBe(true);
+      expect(isPositive(d1)).toBe(false);
+      expect(isPositive(d2)).toBe(false);
     });
   });
 });

--- a/website/data/docs/api/comparisons/is-positive.mdx
+++ b/website/data/docs/api/comparisons/is-positive.mdx
@@ -50,5 +50,5 @@ import { USD } from '@dinero.js/currencies';
 
 const d = dinero({ amount: 0, currency: USD });
 
-isPositive(d); // true
+isPositive(d); // false
 ```


### PR DESCRIPTION
The function `isPositive` should return `false` when passing Dinero objects with amount `0` or `-0`, as zero is unsigned—neither negative nor positive.