### PR TITLE
fix: Update doc quick-start fixing typo on initialization example

### DIFF
--- a/website/data/docs/getting-started/quick-start.mdx
+++ b/website/data/docs/getting-started/quick-start.mdx
@@ -83,7 +83,7 @@ The library is globally available in the docs for you to test it right in the br
 
 To get started, you need to create a new Dinero object. Amounts are specified in minor currency units (like "cents" for the dollar) and currencies in `Currency` objects.
 
-This represents $50:
+This represents $5000:
 
 ```js
 const price = dinero({ amount: 5000, currency: USD });


### PR DESCRIPTION
The docs create an instance of Dinero with an amount of 5000 but the text example says its $50, which could lead to confusion for newcomers