### PR TITLE
fix(toDecimal): do not append decimal string when scale is zero.

### DIFF
--- a/packages/core/src/api/toDecimal.ts
+++ b/packages/core/src/api/toDecimal.ts
@@ -58,7 +58,8 @@ function getDecimal<TAmount>(
     const fractional = formatter.toString(absoluteFn(units[1]));
 
     const scaleNumber = formatter.toNumber(scale);
-    const decimal = `${whole}.${fractional.padStart(scaleNumber, '0')}`;
+    const fractionalString = scaleNumber > 0 ? `.${fractional.padStart(scaleNumber, '0')}` : '';
+    const decimal = `${whole}${fractionalString}`;
 
     const leadsWithZero = equalFn(units[0], zero);
     const isNegative = lessThanFn(units[1], zero);

--- a/packages/dinero.js/src/api/__tests__/toDecimal.test.ts
+++ b/packages/dinero.js/src/api/__tests__/toDecimal.test.ts
@@ -1,4 +1,4 @@
-import { MGA, USD } from '@dinero.js/currencies';
+import {JPY, MGA, USD} from '@dinero.js/currencies';
 import Big from 'big.js';
 import {
   castToBigintCurrency,
@@ -8,7 +8,7 @@ import {
   createBigjsDinero,
 } from 'test-utils';
 
-import { toDecimal } from '..';
+import {toDecimal} from '..';
 
 describe('toDecimal', () => {
   describe('number', () => {
@@ -62,6 +62,12 @@ describe('toDecimal', () => {
           toDecimal(d, ({ value, currency }) => `${currency.code} ${value}`)
         ).toBe('USD 10.50');
       });
+
+     it('returns whole numbers when scale is zero', () => {
+       const d = dinero({ amount: 100, currency: JPY });
+       expect(toDecimal(d)).toEqual('100');
+     });
+
     });
     describe('non-decimal currencies', () => {
       it('throws when passing a Dinero object using a non-decimal currency', () => {
@@ -91,6 +97,7 @@ describe('toDecimal', () => {
     const dinero = createBigintDinero;
     const bigintUSD = castToBigintCurrency(USD);
     const bigintMGA = castToBigintCurrency(MGA);
+    const bigintJPY = castToBigintCurrency(JPY);
 
     describe('decimal currencies', () => {
       it('returns the amount in decimal format', () => {
@@ -145,6 +152,10 @@ describe('toDecimal', () => {
           toDecimal(d, ({ value, currency }) => `${currency.code} ${value}`)
         ).toBe('USD 10.50');
       });
+      it('returns whole numbers when scale is zero', () => {
+        const d = dinero({ amount: 100n, currency: bigintJPY });
+        expect(toDecimal(d)).toEqual('100');
+      });
     });
     describe('non-decimal currencies', () => {
       it('throws when passing a Dinero object using a non-decimal currency', () => {
@@ -174,6 +185,7 @@ describe('toDecimal', () => {
     const dinero = createBigjsDinero;
     const bigjsUSD = castToBigjsCurrency(USD);
     const bigjsMGA = castToBigjsCurrency(MGA);
+    const bigjsJPY = castToBigjsCurrency(JPY);
 
     describe('decimal currencies', () => {
       it('returns the amount in decimal format', () => {
@@ -235,6 +247,11 @@ describe('toDecimal', () => {
           toDecimal(d, ({ value, currency }) => `${currency.code} ${value}`)
         ).toBe('USD 10.50');
       });
+      it('returns whole numbers when scale is zero', () => {
+        const d = dinero({ amount: new Big(100), currency: bigjsJPY });
+        expect(toDecimal(d)).toEqual('100');
+      });
+
     });
     describe('non-decimal currencies', () => {
       it('throws when passing a Dinero object using a non-decimal currency', () => {


### PR DESCRIPTION
Fix for #751 

When the scale is zero, do not append the fractional string.