### PR TITLE
test: Ensure return types of functions.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
   rules: {
     'functional/no-conditional-statement': ['off'],
     'functional/functional-parameters': ['off'],
-    '@typescript-eslint/explicit-function-return-type': ['off'],
+    '@typescript-eslint/explicit-function-return-type': ['warn'],
     'valid-jsdoc': [
       'error',
       {

--- a/packages/calculator-bigint/package.json
+++ b/packages/calculator-bigint/package.json
@@ -29,7 +29,9 @@
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",

--- a/packages/calculator-bigint/src/api/zero.ts
+++ b/packages/calculator-bigint/src/api/zero.ts
@@ -3,6 +3,6 @@
  *
  * @returns Zero as a bigint.
  */
-export function zero() {
+export function zero(): bigint {
   return 0n;
 }

--- a/packages/calculator-number/package.json
+++ b/packages/calculator-number/package.json
@@ -29,7 +29,9 @@
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",

--- a/packages/calculator-number/src/api/zero.ts
+++ b/packages/calculator-number/src/api/zero.ts
@@ -3,6 +3,6 @@
  *
  * @returns Zero as a number.
  */
-export function zero() {
+export function zero(): number {
   return 0;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,12 @@
   "name": "@dinero.js/core",
   "version": "2.0.0-alpha.14",
   "description": "Common code between Dinero.js packages",
-  "keywords": ["money", "monetary", "amount", "immutable"],
+  "keywords": [
+    "money",
+    "monetary",
+    "amount",
+    "immutable"
+  ],
   "homepage": "https://v2.dinerojs.com",
   "bugs": "https://github.com/dinerojs/dinero.js/issues",
   "repository": {
@@ -22,7 +27,9 @@
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",

--- a/packages/core/src/api/add.ts
+++ b/packages/core/src/api/add.ts
@@ -12,7 +12,9 @@ export type AddParams<TAmount> = readonly [
 ];
 
 function unsafeAdd<TAmount>(calculator: Calculator<TAmount>) {
-  return function add(...[augend, addend]: AddParams<TAmount>) {
+  return function add(
+    ...[augend, addend]: AddParams<TAmount>
+  ): Dinero<TAmount> {
     const { amount: augendAmount, currency, scale } = augend.toJSON();
     const { amount: addendAmount } = addend.toJSON();
 
@@ -26,7 +28,9 @@ function unsafeAdd<TAmount>(calculator: Calculator<TAmount>) {
   };
 }
 
-export function safeAdd<TAmount>(calculator: Calculator<TAmount>) {
+export function safeAdd<TAmount>(
+  calculator: Calculator<TAmount>
+): (augend: Dinero<TAmount>, addend: Dinero<TAmount>) => Dinero<TAmount> {
   const normalizeFn = normalizeScale(calculator);
   const addFn = unsafeAdd(calculator);
 

--- a/packages/core/src/api/compare.ts
+++ b/packages/core/src/api/compare.ts
@@ -1,7 +1,7 @@
 /* eslint-disable functional/no-expression-statement */
 import { UNEQUAL_CURRENCIES_MESSAGE } from '../checks';
 import { assert } from '../helpers';
-import type { Calculator, Dinero } from '../types';
+import type { Calculator, ComparisonOperator, Dinero } from '../types';
 import { compare as cmp } from '../utils';
 
 import { haveSameCurrency } from './haveSameCurrency';
@@ -12,12 +12,17 @@ export type CompareParams<TAmount> = readonly [
   comparator: Dinero<TAmount>
 ];
 
-function unsafeCompare<TAmount>(calculator: Calculator<TAmount>) {
+function unsafeCompare<TAmount>(
+  calculator: Calculator<TAmount>
+): (
+  dineroObject: Dinero<TAmount>,
+  comparator: Dinero<TAmount>
+) => ComparisonOperator {
   const compareFn = cmp(calculator);
 
   return function compare(
     ...[dineroObject, comparator]: CompareParams<TAmount>
-  ) {
+  ): ComparisonOperator {
     const dineroObjects = [dineroObject, comparator];
 
     const [subjectAmount, comparatorAmount] = dineroObjects.map((d) => {
@@ -30,13 +35,18 @@ function unsafeCompare<TAmount>(calculator: Calculator<TAmount>) {
   };
 }
 
-export function safeCompare<TAmount>(calculator: Calculator<TAmount>) {
+export function safeCompare<TAmount>(
+  calculator: Calculator<TAmount>
+): (
+  dineroObject: Dinero<TAmount>,
+  comparator: Dinero<TAmount>
+) => ComparisonOperator {
   const normalizeFn = normalizeScale(calculator);
   const compareFn = unsafeCompare(calculator);
 
   return function compare(
     ...[dineroObject, comparator]: CompareParams<TAmount>
-  ) {
+  ): ComparisonOperator {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/core/src/api/convert.ts
+++ b/packages/core/src/api/convert.ts
@@ -11,14 +11,20 @@ export type ConvertParams<TAmount> = readonly [
   rates: Rates<TAmount>
 ];
 
-export function convert<TAmount>(calculator: Calculator<TAmount>) {
+export function convert<TAmount>(
+  calculator: Calculator<TAmount>
+): (
+  dineroObject: Dinero<TAmount>,
+  newCurrency: Currency<TAmount>,
+  rates: Rates<TAmount>
+) => Dinero<TAmount> {
   const convertScaleFn = transformScale(calculator);
   const maximumFn = maximum(calculator);
   const zero = calculator.zero();
 
   return function convertFn(
     ...[dineroObject, newCurrency, rates]: ConvertParams<TAmount>
-  ) {
+  ): Dinero<TAmount> {
     const rate = rates[newCurrency.code];
     const { amount, scale } = dineroObject.toJSON();
     const { amount: rateAmount, scale: rateScale } = getAmountAndScale(
@@ -26,7 +32,7 @@ export function convert<TAmount>(calculator: Calculator<TAmount>) {
       zero
     );
 
-    const newScale = calculator.add(scale, rateScale);
+    const newScale = calculator.add(scale, rateScale ?? zero);
 
     return convertScaleFn(
       dineroObject.create({

--- a/packages/core/src/api/equal.ts
+++ b/packages/core/src/api/equal.ts
@@ -9,7 +9,9 @@ export type EqualParams<TAmount> = readonly [
 ];
 
 export function equal<TAmount>(calculator: Calculator<TAmount>) {
-  return function _equal(...[dineroObject, comparator]: EqualParams<TAmount>) {
+  return function _equal(
+    ...[dineroObject, comparator]: EqualParams<TAmount>
+  ): boolean {
     return (
       haveSameAmount(calculator)([dineroObject, comparator]) &&
       haveSameCurrency([dineroObject, comparator])

--- a/packages/core/src/api/greaterThan.ts
+++ b/packages/core/src/api/greaterThan.ts
@@ -12,12 +12,14 @@ export type GreaterThanParams<TAmount> = readonly [
   comparator: Dinero<TAmount>
 ];
 
-function unsafeGreaterThan<TAmount>(calculator: Calculator<TAmount>) {
+function unsafeGreaterThan<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean {
   const greaterThanFn = gt(calculator);
 
   return function greaterThan(
     ...[dineroObject, comparator]: GreaterThanParams<TAmount>
-  ) {
+  ): boolean {
     const dineroObjects = [dineroObject, comparator];
 
     const [subjectAmount, comparatorAmount] = dineroObjects.map((d) => {
@@ -30,13 +32,15 @@ function unsafeGreaterThan<TAmount>(calculator: Calculator<TAmount>) {
   };
 }
 
-export function safeGreaterThan<TAmount>(calculator: Calculator<TAmount>) {
+export function safeGreaterThan<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean {
   const normalizeFn = normalizeScale(calculator);
   const greaterThanFn = unsafeGreaterThan(calculator);
 
   return function greaterThan(
     ...[dineroObject, comparator]: GreaterThanParams<TAmount>
-  ) {
+  ): boolean {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/core/src/api/greaterThanOrEqual.ts
+++ b/packages/core/src/api/greaterThanOrEqual.ts
@@ -12,12 +12,14 @@ export type GreaterThanOrEqualParams<TAmount> = readonly [
   comparator: Dinero<TAmount>
 ];
 
-function unsafeGreaterThanOrEqual<TAmount>(calculator: Calculator<TAmount>) {
+function unsafeGreaterThanOrEqual<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean {
   const greaterThanOrEqualFn = gte(calculator);
 
   return function greaterThanOrEqual(
     ...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount>
-  ) {
+  ): boolean {
     const dineroObjects = [dineroObject, comparator];
 
     const [subjectAmount, comparatorAmount] = dineroObjects.map((d) => {
@@ -32,13 +34,13 @@ function unsafeGreaterThanOrEqual<TAmount>(calculator: Calculator<TAmount>) {
 
 export function safeGreaterThanOrEqual<TAmount>(
   calculator: Calculator<TAmount>
-) {
+): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean {
   const normalizeFn = normalizeScale(calculator);
   const greaterThanOrEqualFn = unsafeGreaterThanOrEqual(calculator);
 
   return function greaterThanOrEqual(
     ...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount>
-  ) {
+  ): boolean {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/core/src/api/hasSubUnits.ts
+++ b/packages/core/src/api/hasSubUnits.ts
@@ -5,11 +5,15 @@ export type HasSubUnitsParams<TAmount> = readonly [
   dineroObject: Dinero<TAmount>
 ];
 
-export function hasSubUnits<TAmount>(calculator: Calculator<TAmount>) {
+export function hasSubUnits<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>) => boolean {
   const equalFn = equal(calculator);
   const computeBaseFn = computeBase(calculator);
 
-  return function _hasSubUnits(...[dineroObject]: HasSubUnitsParams<TAmount>) {
+  return function _hasSubUnits(
+    ...[dineroObject]: HasSubUnitsParams<TAmount>
+  ): boolean {
     const { amount, currency, scale } = dineroObject.toJSON();
     const base = computeBaseFn(currency.base);
 

--- a/packages/core/src/api/haveSameAmount.ts
+++ b/packages/core/src/api/haveSameAmount.ts
@@ -7,7 +7,9 @@ export type HaveSameAmountParams<TAmount> = readonly [
   dineroObjects: ReadonlyArray<Dinero<TAmount>>
 ];
 
-export function haveSameAmount<TAmount>(calculator: Calculator<TAmount>) {
+export function haveSameAmount<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObjects: ReadonlyArray<Dinero<TAmount>>) => boolean {
   const normalizeFn = normalizeScale(calculator);
   const equalFn = equal(calculator);
 

--- a/packages/core/src/api/haveSameCurrency.ts
+++ b/packages/core/src/api/haveSameCurrency.ts
@@ -3,7 +3,7 @@ import { computeBase, equal } from '../utils';
 
 export function haveSameCurrency<TAmount>(
   dineroObjects: ReadonlyArray<Dinero<TAmount>>
-) {
+): boolean {
   const [firstDinero, ...otherDineros] = dineroObjects;
   const computeBaseFn = computeBase(firstDinero.calculator);
 

--- a/packages/core/src/api/isNegative.ts
+++ b/packages/core/src/api/isNegative.ts
@@ -5,10 +5,14 @@ export type IsNegativeParams<TAmount> = readonly [
   dineroObject: Dinero<TAmount>
 ];
 
-export function isNegative<TAmount>(calculator: Calculator<TAmount>) {
+export function isNegative<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>) => boolean {
   const lessThanFn = lessThan(calculator);
 
-  return function _isNegative(...[dineroObject]: IsNegativeParams<TAmount>) {
+  return function _isNegative(
+    ...[dineroObject]: IsNegativeParams<TAmount>
+  ): boolean {
     const { amount } = dineroObject.toJSON();
 
     return lessThanFn(amount, calculator.zero());

--- a/packages/core/src/api/isPositive.ts
+++ b/packages/core/src/api/isPositive.ts
@@ -5,10 +5,14 @@ export type IsPositiveParams<TAmount> = readonly [
   dineroObject: Dinero<TAmount>
 ];
 
-export function isPositive<TAmount>(calculator: Calculator<TAmount>) {
+export function isPositive<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>) => boolean {
   const greaterThanFn = greaterThan(calculator);
 
-  return function _isPositive(...[dineroObject]: IsPositiveParams<TAmount>) {
+  return function _isPositive(
+    ...[dineroObject]: IsPositiveParams<TAmount>
+  ): boolean {
     const { amount } = dineroObject.toJSON();
 
     return greaterThanFn(amount, calculator.zero());

--- a/packages/core/src/api/isZero.ts
+++ b/packages/core/src/api/isZero.ts
@@ -3,10 +3,12 @@ import { equal } from '../utils';
 
 export type IsZeroParams<TAmount> = readonly [dineroObject: Dinero<TAmount>];
 
-export function isZero<TAmount>(calculator: Calculator<TAmount>) {
+export function isZero<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>) => boolean {
   const equalFn = equal(calculator);
 
-  return function _isZero(...[dineroObject]: IsZeroParams<TAmount>) {
+  return function _isZero(...[dineroObject]: IsZeroParams<TAmount>): boolean {
     const { amount } = dineroObject.toJSON();
 
     return equalFn(amount, calculator.zero());

--- a/packages/core/src/api/lessThan.ts
+++ b/packages/core/src/api/lessThan.ts
@@ -12,12 +12,14 @@ export type LessThanParams<TAmount> = readonly [
   comparator: Dinero<TAmount>
 ];
 
-function unsafeLessThan<TAmount>(calculator: Calculator<TAmount>) {
+function unsafeLessThan<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean {
   const lessThanFn = lt(calculator);
 
   return function lessThan(
     ...[dineroObject, comparator]: LessThanParams<TAmount>
-  ) {
+  ): boolean {
     const dineroObjects = [dineroObject, comparator];
 
     const [subjectAmount, comparatorAmount] = dineroObjects.map((d) => {
@@ -30,13 +32,15 @@ function unsafeLessThan<TAmount>(calculator: Calculator<TAmount>) {
   };
 }
 
-export function safeLessThan<TAmount>(calculator: Calculator<TAmount>) {
+export function safeLessThan<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean {
   const normalizeFn = normalizeScale(calculator);
   const lessThanFn = unsafeLessThan(calculator);
 
   return function lessThan(
     ...[dineroObject, comparator]: LessThanParams<TAmount>
-  ) {
+  ): boolean {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/core/src/api/lessThanOrEqual.ts
+++ b/packages/core/src/api/lessThanOrEqual.ts
@@ -12,12 +12,14 @@ export type LessThanOrEqualParams<TAmount> = readonly [
   comparator: Dinero<TAmount>
 ];
 
-function unsafeLessThanOrEqual<TAmount>(calculator: Calculator<TAmount>) {
+function unsafeLessThanOrEqual<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean {
   const lessThanOrEqualFn = lte(calculator);
 
   return function lessThanOrEqual(
     ...[dineroObject, comparator]: LessThanOrEqualParams<TAmount>
-  ) {
+  ): boolean {
     const dineroObjects = [dineroObject, comparator];
 
     const [subjectAmount, comparatorAmount] = dineroObjects.map((d) => {
@@ -30,13 +32,15 @@ function unsafeLessThanOrEqual<TAmount>(calculator: Calculator<TAmount>) {
   };
 }
 
-export function safeLessThanOrEqual<TAmount>(calculator: Calculator<TAmount>) {
+export function safeLessThanOrEqual<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>, comparator: Dinero<TAmount>) => boolean {
   const normalizeFn = normalizeScale(calculator);
   const lessThanOrEqualFn = unsafeLessThanOrEqual(calculator);
 
   return function lessThanOrEqual(
     ...[dineroObject, comparator]: LessThanOrEqualParams<TAmount>
-  ) {
+  ): boolean {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/core/src/api/maximum.ts
+++ b/packages/core/src/api/maximum.ts
@@ -11,10 +11,14 @@ export type MaximumParams<TAmount> = readonly [
   dineroObjects: ReadonlyArray<Dinero<TAmount>>
 ];
 
-function unsafeMaximum<TAmount>(calculator: Calculator<TAmount>) {
+function unsafeMaximum<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObjects: ReadonlyArray<Dinero<TAmount>>) => Dinero<TAmount> {
   const maxFn = max(calculator);
 
-  return function maximum(...[dineroObjects]: MaximumParams<TAmount>) {
+  return function maximum(
+    ...[dineroObjects]: MaximumParams<TAmount>
+  ): Dinero<TAmount> {
     const [firstDinero] = dineroObjects;
     const { currency, scale } = firstDinero.toJSON();
 
@@ -34,11 +38,15 @@ function unsafeMaximum<TAmount>(calculator: Calculator<TAmount>) {
   };
 }
 
-export function safeMaximum<TAmount>(calculator: Calculator<TAmount>) {
+export function safeMaximum<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObjects: ReadonlyArray<Dinero<TAmount>>) => Dinero<TAmount> {
   const normalizeFn = normalizeScale(calculator);
   const maxFn = unsafeMaximum(calculator);
 
-  return function maximum(...[dineroObjects]: MaximumParams<TAmount>) {
+  return function maximum(
+    ...[dineroObjects]: MaximumParams<TAmount>
+  ): Dinero<TAmount> {
     const condition = haveSameCurrency(dineroObjects);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/core/src/api/minimum.ts
+++ b/packages/core/src/api/minimum.ts
@@ -11,7 +11,9 @@ export type MinimumParams<TAmount> = readonly [
   dineroObjects: ReadonlyArray<Dinero<TAmount>>
 ];
 
-function unsafeMinimum<TAmount>(calculator: Calculator<TAmount>) {
+function unsafeMinimum<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObjects: ReadonlyArray<Dinero<TAmount>>) => Dinero<TAmount> {
   const minFn = min(calculator);
 
   return function minimum(...[dineroObjects]: MinimumParams<TAmount>) {
@@ -34,11 +36,15 @@ function unsafeMinimum<TAmount>(calculator: Calculator<TAmount>) {
   };
 }
 
-export function safeMinimum<TAmount>(calculator: Calculator<TAmount>) {
+export function safeMinimum<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObjects: ReadonlyArray<Dinero<TAmount>>) => Dinero<TAmount> {
   const normalizeFn = normalizeScale(calculator);
   const minFn = unsafeMinimum(calculator);
 
-  return function maximum(...[dineroObjects]: MinimumParams<TAmount>) {
+  return function maximum(
+    ...[dineroObjects]: MinimumParams<TAmount>
+  ): Dinero<TAmount> {
     const condition = haveSameCurrency(dineroObjects);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/core/src/api/multiply.ts
+++ b/packages/core/src/api/multiply.ts
@@ -8,18 +8,23 @@ export type MultiplyParams<TAmount> = readonly [
   multiplier: ScaledAmount<TAmount> | TAmount
 ];
 
-export function multiply<TAmount>(calculator: Calculator<TAmount>) {
+export function multiply<TAmount>(
+  calculator: Calculator<TAmount>
+): (
+  multiplicand: Dinero<TAmount>,
+  multiplier: ScaledAmount<TAmount> | TAmount
+) => Dinero<TAmount> {
   const convertScaleFn = transformScale(calculator);
   const zero = calculator.zero();
 
   return function multiplyFn(
     ...[multiplicand, multiplier]: MultiplyParams<TAmount>
-  ) {
+  ): Dinero<TAmount> {
     const { amount, currency, scale } = multiplicand.toJSON();
     const { amount: multiplierAmount, scale: multiplierScale } =
       getAmountAndScale(multiplier, zero);
 
-    const newScale = calculator.add(scale, multiplierScale);
+    const newScale = calculator.add(scale, multiplierScale ?? zero);
 
     return convertScaleFn(
       multiplicand.create({

--- a/packages/core/src/api/normalizeScale.ts
+++ b/packages/core/src/api/normalizeScale.ts
@@ -7,14 +7,18 @@ export type NormalizeScaleParams<TAmount> = readonly [
   dineroObjects: ReadonlyArray<Dinero<TAmount>>
 ];
 
-export function normalizeScale<TAmount>(calculator: Calculator<TAmount>) {
+export function normalizeScale<TAmount>(
+  calculator: Calculator<TAmount>
+): (
+  dineroObjects: ReadonlyArray<Dinero<TAmount>>
+) => ReadonlyArray<Dinero<TAmount>> {
   const maximumFn = maximum(calculator);
   const convertScaleFn = transformScale(calculator);
   const equalFn = equal(calculator);
 
   return function _normalizeScale(
     ...[dineroObjects]: NormalizeScaleParams<TAmount>
-  ) {
+  ): ReadonlyArray<Dinero<TAmount>> {
     const highestScale = dineroObjects.reduce((highest, current) => {
       const { scale } = current.toJSON();
 

--- a/packages/core/src/api/subtract.ts
+++ b/packages/core/src/api/subtract.ts
@@ -12,7 +12,9 @@ export type SubtractParams<TAmount> = readonly [
 ];
 
 function unsafeSubtract<TAmount>(calculator: Calculator<TAmount>) {
-  return function subtract(...[minuend, subtrahend]: SubtractParams<TAmount>) {
+  return function subtract(
+    ...[minuend, subtrahend]: SubtractParams<TAmount>
+  ): Dinero<TAmount> {
     const { amount: minuendAmount, currency, scale } = minuend.toJSON();
     const { amount: subtrahendAmount } = subtrahend.toJSON();
 
@@ -26,11 +28,15 @@ function unsafeSubtract<TAmount>(calculator: Calculator<TAmount>) {
   };
 }
 
-export function safeSubtract<TAmount>(calculator: Calculator<TAmount>) {
+export function safeSubtract<TAmount>(
+  calculator: Calculator<TAmount>
+): (minuend: Dinero<TAmount>, subtrahend: Dinero<TAmount>) => Dinero<TAmount> {
   const normalizeFn = normalizeScale(calculator);
   const subtractFn = unsafeSubtract(calculator);
 
-  return function subtract(...[minuend, subtrahend]: SubtractParams<TAmount>) {
+  return function subtract(
+    ...[minuend, subtrahend]: SubtractParams<TAmount>
+  ): Dinero<TAmount> {
     const condition = haveSameCurrency([minuend, subtrahend]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/core/src/api/toDecimal.ts
+++ b/packages/core/src/api/toDecimal.ts
@@ -10,7 +10,12 @@ export type ToDecimalParams<TAmount, TOutput> = readonly [
   transformer?: Transformer<TAmount, TOutput, string>
 ];
 
-export function toDecimal<TAmount, TOutput>(calculator: Calculator<TAmount>) {
+export function toDecimal<TAmount, TOutput>(
+  calculator: Calculator<TAmount>
+): (
+  dineroObject: Dinero<TAmount>,
+  transformer?: Transformer<TAmount, TOutput, string> | undefined
+) => TOutput | string {
   const toUnitsFn = toUnits<TAmount, readonly TAmount[]>(calculator);
   const computeBaseFn = computeBase(calculator);
   const equalFn = equal(calculator);
@@ -47,7 +52,7 @@ export function toDecimal<TAmount, TOutput>(calculator: Calculator<TAmount>) {
 function getDecimal<TAmount>(
   calculator: Calculator<TAmount>,
   formatter: Formatter<TAmount>
-) {
+): (units: readonly TAmount[], scale: TAmount) => string {
   const absoluteFn = absolute(calculator);
   const equalFn = equal(calculator);
   const lessThanFn = lessThan(calculator);

--- a/packages/core/src/api/toSnapshot.ts
+++ b/packages/core/src/api/toSnapshot.ts
@@ -1,5 +1,7 @@
-import type { Dinero } from '../types';
+import type { Dinero, DineroSnapshot } from '../types';
 
-export function toSnapshot<TAmount>(dineroObject: Dinero<TAmount>) {
+export function toSnapshot<TAmount>(
+  dineroObject: Dinero<TAmount>
+): DineroSnapshot<TAmount> {
   return dineroObject.toJSON();
 }

--- a/packages/core/src/api/toUnits.ts
+++ b/packages/core/src/api/toUnits.ts
@@ -6,12 +6,17 @@ export type ToUnitsParams<TAmount, TOutput> = readonly [
   transformer?: Transformer<TAmount, TOutput, readonly TAmount[]>
 ];
 
-export function toUnits<TAmount, TOutput>(calculator: Calculator<TAmount>) {
+export function toUnits<TAmount, TOutput>(
+  calculator: Calculator<TAmount>
+): (
+  dineroObject: Dinero<TAmount>,
+  transformer?: Transformer<TAmount, TOutput, readonly TAmount[]> | undefined
+) => TOutput | readonly TAmount[] {
   const getDivisorsFn = getDivisors(calculator);
 
   return function toUnitsFn(
     ...[dineroObject, transformer]: ToUnitsParams<TAmount, TOutput>
-  ) {
+  ): TOutput | readonly TAmount[] {
     const { amount, currency, scale } = dineroObject.toJSON();
     const { power, integerDivide, modulo } = calculator;
 

--- a/packages/core/src/api/transformScale.ts
+++ b/packages/core/src/api/transformScale.ts
@@ -8,13 +8,19 @@ export type TransformScaleParams<TAmount> = readonly [
   divide?: DivideOperation
 ];
 
-export function transformScale<TAmount>(calculator: Calculator<TAmount>) {
+export function transformScale<TAmount>(
+  calculator: Calculator<TAmount>
+): (
+  dineroObject: Dinero<TAmount>,
+  newScale: TAmount,
+  divide?: DivideOperation | undefined
+) => Dinero<TAmount> {
   const greaterThanFn = greaterThan(calculator);
   const computeBaseFn = computeBase(calculator);
 
   return function transformScaleFn(
     ...[dineroObject, newScale, divide = down]: TransformScaleParams<TAmount>
-  ) {
+  ): Dinero<TAmount> {
     const { amount, currency, scale } = dineroObject.toJSON();
 
     const isLarger = greaterThanFn(newScale, scale);

--- a/packages/core/src/api/trimScale.ts
+++ b/packages/core/src/api/trimScale.ts
@@ -5,14 +5,18 @@ import { transformScale } from './transformScale';
 
 export type TrimScaleParams<TAmount> = readonly [dineroObject: Dinero<TAmount>];
 
-export function trimScale<TAmount>(calculator: Calculator<TAmount>) {
+export function trimScale<TAmount>(
+  calculator: Calculator<TAmount>
+): (dineroObject: Dinero<TAmount>) => Dinero<TAmount> {
   const countTrailingZerosFn = countTrailingZeros(calculator);
   const equalFn = equal(calculator);
   const maximumFn = maximum(calculator);
   const transformScaleFn = transformScale(calculator);
   const computeBaseFn = computeBase(calculator);
 
-  return function trimScaleFn(...[dineroObject]: TrimScaleParams<TAmount>) {
+  return function trimScaleFn(
+    ...[dineroObject]: TrimScaleParams<TAmount>
+  ): Dinero<TAmount> {
     const { amount, currency, scale } = dineroObject.toJSON();
     const base = computeBaseFn(currency.base);
 

--- a/packages/core/src/helpers/assert.ts
+++ b/packages/core/src/helpers/assert.ts
@@ -1,3 +1,4 @@
+/* eslint-disable functional/no-return-void */
 /* eslint-disable functional/no-throw-statement, valid-jsdoc */
 /**
  * Assert a condition.
@@ -7,7 +8,7 @@
  *
  * @throws If the condition isn't met.
  */
-export function assert(condition: boolean, message: string) {
+export function assert(condition: boolean, message: string): void {
   if (!condition) {
     throw new Error(`[Dinero.js] ${message}`);
   }

--- a/packages/core/src/helpers/createDinero.ts
+++ b/packages/core/src/helpers/createDinero.ts
@@ -1,5 +1,11 @@
 /* eslint-disable functional/no-mixed-type, functional/no-return-void, functional/no-expression-statement */
-import type { Calculator, Dinero, DineroOptions, Formatter } from '../types';
+import type {
+  Calculator,
+  Dinero,
+  DineroOptions,
+  DineroSnapshot,
+  Formatter,
+} from '../types';
 
 export type CreateDineroOptions<TAmount> = {
   readonly calculator: Calculator<TAmount>;
@@ -28,7 +34,7 @@ export function createDinero<TAmount>({
       calculator,
       formatter,
       create: dinero,
-      toJSON() {
+      toJSON(): DineroSnapshot<TAmount> {
         return {
           amount,
           currency,

--- a/packages/core/src/utils/absolute.ts
+++ b/packages/core/src/utils/absolute.ts
@@ -3,7 +3,9 @@ import type { Calculator } from '../types';
 import { equal } from './equal';
 import { lessThan } from './lessThan';
 
-export function absolute<TAmount>(calculator: Calculator<TAmount>) {
+export function absolute<TAmount>(
+  calculator: Calculator<TAmount>
+): (input: TAmount) => TAmount {
   const equalFn = equal(calculator);
   const lessThanFn = lessThan(calculator);
   const zero = calculator.zero();

--- a/packages/core/src/utils/compare.ts
+++ b/packages/core/src/utils/compare.ts
@@ -1,4 +1,4 @@
-import type { Calculator } from '../types';
+import type { Calculator, ComparisonOperator } from '../types';
 
 type ComparisonCalculator<TAmount> = Calculator<TAmount>;
 
@@ -9,7 +9,9 @@ type ComparisonCalculator<TAmount> = Calculator<TAmount>;
  *
  * @returns The compare function.
  */
-export function compare<TAmount>(calculator: ComparisonCalculator<TAmount>) {
+export function compare<TAmount>(
+  calculator: ComparisonCalculator<TAmount>
+): (subject: TAmount, comparator: TAmount) => ComparisonOperator {
   return (subject: TAmount, comparator: TAmount) => {
     return calculator.compare(subject, comparator);
   };

--- a/packages/core/src/utils/computeBase.ts
+++ b/packages/core/src/utils/computeBase.ts
@@ -2,7 +2,9 @@ import type { Calculator } from '../types';
 
 import { isArray } from './isArray';
 
-export function computeBase<TAmount>(calculator: Calculator<TAmount>) {
+export function computeBase<TAmount>(
+  calculator: Calculator<TAmount>
+): (base: TAmount | readonly TAmount[]) => TAmount {
   return (base: TAmount | readonly TAmount[]) => {
     if (isArray(base)) {
       return base.reduce((acc, curr) => calculator.multiply(acc, curr));

--- a/packages/core/src/utils/countTrailingZeros.ts
+++ b/packages/core/src/utils/countTrailingZeros.ts
@@ -7,7 +7,7 @@ type CountTrailingZerosCalculator<TAmount> = Calculator<TAmount>;
 
 export function countTrailingZeros<TAmount>(
   calculator: CountTrailingZerosCalculator<TAmount>
-) {
+): (input: TAmount, base: TAmount) => TAmount {
   const equalFn = equal(calculator);
 
   return (input: TAmount, base: TAmount) => {

--- a/packages/core/src/utils/distribute.ts
+++ b/packages/core/src/utils/distribute.ts
@@ -16,7 +16,9 @@ type DistributeCalculator<TAmount> = Calculator<TAmount>;
  *
  * @returns The distribute function.
  */
-export function distribute<TAmount>(calculator: DistributeCalculator<TAmount>) {
+export function distribute<TAmount>(
+  calculator: DistributeCalculator<TAmount>
+): (value: TAmount, ratios: readonly TAmount[]) => readonly TAmount[] {
   return (value: TAmount, ratios: readonly TAmount[]) => {
     const equalFn = equal(calculator);
     const greaterThanFn = greaterThan(calculator);

--- a/packages/core/src/utils/equal.ts
+++ b/packages/core/src/utils/equal.ts
@@ -10,7 +10,9 @@ type EqualCalculator<TAmount> = Calculator<TAmount>;
  *
  * @returns The equal function.
  */
-export function equal<TAmount>(calculator: EqualCalculator<TAmount>) {
+export function equal<TAmount>(
+  calculator: EqualCalculator<TAmount>
+): (subject: TAmount, comparator: TAmount) => boolean {
   return (subject: TAmount, comparator: TAmount) => {
     return calculator.compare(subject, comparator) === ComparisonOperator.EQ;
   };

--- a/packages/core/src/utils/getAmountAndScale.ts
+++ b/packages/core/src/utils/getAmountAndScale.ts
@@ -5,7 +5,7 @@ import { isScaledAmount } from './isScaledAmount';
 export function getAmountAndScale<TAmount>(
   value: ScaledAmount<TAmount> | TAmount,
   zero: TAmount
-) {
+): ScaledAmount<TAmount> {
   if (isScaledAmount(value)) {
     return { amount: value.amount, scale: value?.scale ?? zero };
   }

--- a/packages/core/src/utils/getDivisors.ts
+++ b/packages/core/src/utils/getDivisors.ts
@@ -1,6 +1,8 @@
 import type { Calculator } from '../types';
 
-export function getDivisors<TAmount>(calculator: Calculator<TAmount>) {
+export function getDivisors<TAmount>(
+  calculator: Calculator<TAmount>
+): (bases: readonly TAmount[]) => readonly TAmount[] {
   const { multiply } = calculator;
 
   return (bases: readonly TAmount[]) => {

--- a/packages/core/src/utils/greaterThan.ts
+++ b/packages/core/src/utils/greaterThan.ts
@@ -12,7 +12,7 @@ type GreaterThanCalculator<TAmount> = Calculator<TAmount>;
  */
 export function greaterThan<TAmount>(
   calculator: GreaterThanCalculator<TAmount>
-) {
+): (subject: TAmount, comparator: TAmount) => boolean {
   return (subject: TAmount, comparator: TAmount) => {
     return calculator.compare(subject, comparator) === ComparisonOperator.GT;
   };

--- a/packages/core/src/utils/greaterThanOrEqual.ts
+++ b/packages/core/src/utils/greaterThanOrEqual.ts
@@ -14,7 +14,7 @@ type GreaterThanOrEqualCalculator<TAmount> = Calculator<TAmount>;
  */
 export function greaterThanOrEqual<TAmount>(
   calculator: GreaterThanOrEqualCalculator<TAmount>
-) {
+): (subject: TAmount, comparator: TAmount) => boolean {
   return (subject: TAmount, comparator: TAmount) => {
     return (
       greaterThan(calculator)(subject, comparator) ||

--- a/packages/core/src/utils/isEven.ts
+++ b/packages/core/src/utils/isEven.ts
@@ -2,7 +2,9 @@ import type { Calculator } from '../types';
 
 import { equal } from '.';
 
-export function isEven<TAmount>(calculator: Calculator<TAmount>) {
+export function isEven<TAmount>(
+  calculator: Calculator<TAmount>
+): (input: TAmount) => boolean {
   const equalFn = equal(calculator);
   const zero = calculator.zero();
   const two = calculator.increment(calculator.increment(zero));

--- a/packages/core/src/utils/isHalf.ts
+++ b/packages/core/src/utils/isHalf.ts
@@ -2,7 +2,9 @@ import type { Calculator } from '../types';
 
 import { equal, absolute } from '.';
 
-export function isHalf<TAmount>(calculator: Calculator<TAmount>) {
+export function isHalf<TAmount>(
+  calculator: Calculator<TAmount>
+): (input: TAmount, total: TAmount) => boolean {
   const equalFn = equal(calculator);
   const absoluteFn = absolute(calculator);
 

--- a/packages/core/src/utils/lessThan.ts
+++ b/packages/core/src/utils/lessThan.ts
@@ -10,7 +10,9 @@ type LessThanCalculator<TAmount> = Calculator<TAmount>;
  *
  * @returns The lessThan function.
  */
-export function lessThan<TAmount>(calculator: LessThanCalculator<TAmount>) {
+export function lessThan<TAmount>(
+  calculator: LessThanCalculator<TAmount>
+): (subject: TAmount, comparator: TAmount) => boolean {
   return (subject: TAmount, comparator: TAmount) => {
     return calculator.compare(subject, comparator) === ComparisonOperator.LT;
   };

--- a/packages/core/src/utils/lessThanOrEqual.ts
+++ b/packages/core/src/utils/lessThanOrEqual.ts
@@ -14,7 +14,7 @@ type LessThanOrEqualCalculator<TAmount> = Calculator<TAmount>;
  */
 export function lessThanOrEqual<TAmount>(
   calculator: LessThanOrEqualCalculator<TAmount>
-) {
+): (subject: TAmount, comparator: TAmount) => boolean {
   return (subject: TAmount, comparator: TAmount) => {
     return (
       lessThan(calculator)(subject, comparator) ||

--- a/packages/core/src/utils/maximum.ts
+++ b/packages/core/src/utils/maximum.ts
@@ -11,7 +11,9 @@ type MaximumCalculator<TAmount> = Calculator<TAmount>;
  *
  * @returns The maximum function.
  */
-export function maximum<TAmount>(calculator: MaximumCalculator<TAmount>) {
+export function maximum<TAmount>(
+  calculator: MaximumCalculator<TAmount>
+): (values: readonly TAmount[]) => TAmount {
   const lessThanFn = lessThan(calculator);
 
   return (values: readonly TAmount[]) => {

--- a/packages/core/src/utils/minimum.ts
+++ b/packages/core/src/utils/minimum.ts
@@ -11,7 +11,9 @@ type MinimumCalculator<TAmount> = Calculator<TAmount>;
  *
  * @returns The minimum function.
  */
-export function minimum<TAmount>(calculator: MinimumCalculator<TAmount>) {
+export function minimum<TAmount>(
+  calculator: MinimumCalculator<TAmount>
+): (values: readonly TAmount[]) => TAmount {
   const greaterThanFn = greaterThan(calculator);
 
   return (values: readonly TAmount[]) => {

--- a/packages/core/src/utils/sign.ts
+++ b/packages/core/src/utils/sign.ts
@@ -3,7 +3,9 @@ import type { Calculator } from '../types';
 import { equal } from './equal';
 import { lessThan } from './lessThan';
 
-export function sign<TAmount>(calculator: Calculator<TAmount>) {
+export function sign<TAmount>(
+  calculator: Calculator<TAmount>
+): (input: TAmount) => TAmount {
   const equalFn = equal(calculator);
   const lessThanFn = lessThan(calculator);
   const zero = calculator.zero();

--- a/packages/dinero.js/package.json
+++ b/packages/dinero.js/package.json
@@ -29,7 +29,9 @@
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",

--- a/packages/dinero.js/src/api/add.ts
+++ b/packages/dinero.js/src/api/add.ts
@@ -1,5 +1,5 @@
 import { safeAdd } from '@dinero.js/core';
-import type { AddParams } from '@dinero.js/core';
+import type { AddParams, Dinero } from '@dinero.js/core';
 
 /**
  * Add up the passed Dinero objects.
@@ -11,7 +11,9 @@ import type { AddParams } from '@dinero.js/core';
  *
  * @public
  */
-export function add<TAmount>(...[augend, addend]: AddParams<TAmount>) {
+export function add<TAmount>(
+  ...[augend, addend]: AddParams<TAmount>
+): Dinero<TAmount> {
   const { calculator } = augend;
   const addFn = safeAdd(calculator);
 

--- a/packages/dinero.js/src/api/allocate.ts
+++ b/packages/dinero.js/src/api/allocate.ts
@@ -1,5 +1,5 @@
 import { safeAllocate } from '@dinero.js/core';
-import type { AllocateParams } from '@dinero.js/core';
+import type { AllocateParams, Dinero } from '@dinero.js/core';
 
 /**
  * Distribute the amount of a Dinero object across a list of ratios.
@@ -13,7 +13,7 @@ import type { AllocateParams } from '@dinero.js/core';
  */
 export function allocate<TAmount>(
   ...[dineroObject, ratios]: AllocateParams<TAmount>
-) {
+): ReadonlyArray<Dinero<TAmount>> {
   const { calculator } = dineroObject;
   const allocateFn = safeAllocate(calculator);
 

--- a/packages/dinero.js/src/api/compare.ts
+++ b/packages/dinero.js/src/api/compare.ts
@@ -1,5 +1,5 @@
 import { safeCompare } from '@dinero.js/core';
-import type { CompareParams } from '@dinero.js/core';
+import type { CompareParams, ComparisonOperator } from '@dinero.js/core';
 
 /**
  * Compare the value of a Dinero object relative to another.
@@ -13,7 +13,7 @@ import type { CompareParams } from '@dinero.js/core';
  */
 export function compare<TAmount>(
   ...[dineroObject, comparator]: CompareParams<TAmount>
-) {
+): ComparisonOperator {
   const { calculator } = dineroObject;
   const compareFn = safeCompare(calculator);
 

--- a/packages/dinero.js/src/api/convert.ts
+++ b/packages/dinero.js/src/api/convert.ts
@@ -1,5 +1,5 @@
 import { convert as coreConvert } from '@dinero.js/core';
-import type { ConvertParams } from '@dinero.js/core';
+import type { ConvertParams, Dinero } from '@dinero.js/core';
 
 /**
  * Convert a Dinero object to another currency.
@@ -14,7 +14,7 @@ import type { ConvertParams } from '@dinero.js/core';
  */
 export function convert<TAmount>(
   ...[dineroObject, newCurrency, rates]: ConvertParams<TAmount>
-) {
+): Dinero<TAmount> {
   const { calculator } = dineroObject;
   const converter = coreConvert(calculator);
 

--- a/packages/dinero.js/src/api/equal.ts
+++ b/packages/dinero.js/src/api/equal.ts
@@ -13,7 +13,7 @@ import type { EqualParams } from '@dinero.js/core';
  */
 export function equal<TAmount>(
   ...[dineroObject, comparator]: EqualParams<TAmount>
-) {
+): boolean {
   const { calculator } = dineroObject;
   const equalFn = coreEqual(calculator);
 

--- a/packages/dinero.js/src/api/greaterThan.ts
+++ b/packages/dinero.js/src/api/greaterThan.ts
@@ -13,7 +13,7 @@ import type { GreaterThanParams } from '@dinero.js/core';
  */
 export function greaterThan<TAmount>(
   ...[dineroObject, comparator]: GreaterThanParams<TAmount>
-) {
+): boolean {
   const { calculator } = dineroObject;
   const greaterThanFn = safeGreaterThan(calculator);
 

--- a/packages/dinero.js/src/api/greaterThanOrEqual.ts
+++ b/packages/dinero.js/src/api/greaterThanOrEqual.ts
@@ -13,7 +13,7 @@ import type { GreaterThanOrEqualParams } from '@dinero.js/core';
  */
 export function greaterThanOrEqual<TAmount>(
   ...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount>
-) {
+): boolean {
   const { calculator } = dineroObject;
   const greaterThanOrEqualFn = safeGreaterThanOrEqual(calculator);
 

--- a/packages/dinero.js/src/api/hasSubUnits.ts
+++ b/packages/dinero.js/src/api/hasSubUnits.ts
@@ -12,7 +12,7 @@ import type { HasSubUnitsParams } from '@dinero.js/core';
  */
 export function hasSubUnits<TAmount>(
   ...[dineroObject]: HasSubUnitsParams<TAmount>
-) {
+): boolean {
   const { calculator } = dineroObject;
   const hasSubUnitsFn = coreHasSubUnits(calculator);
 

--- a/packages/dinero.js/src/api/haveSameAmount.ts
+++ b/packages/dinero.js/src/api/haveSameAmount.ts
@@ -12,7 +12,7 @@ import type { HaveSameAmountParams } from '@dinero.js/core';
  */
 export function haveSameAmount<TAmount>(
   ...[dineroObjects]: HaveSameAmountParams<TAmount>
-) {
+): boolean {
   const { calculator } = dineroObjects[0];
   const haveSameAmountFn = coreHaveSameAmount(calculator);
 

--- a/packages/dinero.js/src/api/isNegative.ts
+++ b/packages/dinero.js/src/api/isNegative.ts
@@ -12,7 +12,7 @@ import type { IsNegativeParams } from '@dinero.js/core';
  */
 export function isNegative<TAmount>(
   ...[dineroObject]: IsNegativeParams<TAmount>
-) {
+): boolean {
   const { calculator } = dineroObject;
   const isNegativeFn = coreIsNegative(calculator);
 

--- a/packages/dinero.js/src/api/isPositive.ts
+++ b/packages/dinero.js/src/api/isPositive.ts
@@ -12,7 +12,7 @@ import type { IsPositiveParams } from '@dinero.js/core';
  */
 export function isPositive<TAmount>(
   ...[dineroObject]: IsPositiveParams<TAmount>
-) {
+): boolean {
   const { calculator } = dineroObject;
   const isPositiveFn = coreIsPositive(calculator);
 

--- a/packages/dinero.js/src/api/isZero.ts
+++ b/packages/dinero.js/src/api/isZero.ts
@@ -10,7 +10,9 @@ import type { IsZeroParams } from '@dinero.js/core';
  *
  * @public
  */
-export function isZero<TAmount>(...[dineroObject]: IsZeroParams<TAmount>) {
+export function isZero<TAmount>(
+  ...[dineroObject]: IsZeroParams<TAmount>
+): boolean {
   const { calculator } = dineroObject;
   const isZeroFn = coreIsZero(calculator);
 

--- a/packages/dinero.js/src/api/lessThan.ts
+++ b/packages/dinero.js/src/api/lessThan.ts
@@ -13,7 +13,7 @@ import type { LessThanParams } from '@dinero.js/core';
  */
 export function lessThan<TAmount>(
   ...[dineroObject, comparator]: LessThanParams<TAmount>
-) {
+): boolean {
   const { calculator } = dineroObject;
   const lessThanFn = safeLessThan(calculator);
 

--- a/packages/dinero.js/src/api/lessThanOrEqual.ts
+++ b/packages/dinero.js/src/api/lessThanOrEqual.ts
@@ -13,7 +13,7 @@ import type { LessThanOrEqualParams } from '@dinero.js/core';
  */
 export function lessThanOrEqual<TAmount>(
   ...[dineroObject, comparator]: LessThanOrEqualParams<TAmount>
-) {
+): boolean {
   const { calculator } = dineroObject;
   const lessThanOrEqualFn = safeLessThanOrEqual(calculator);
 

--- a/packages/dinero.js/src/api/maximum.ts
+++ b/packages/dinero.js/src/api/maximum.ts
@@ -1,5 +1,5 @@
 import { safeMaximum } from '@dinero.js/core';
-import type { MaximumParams } from '@dinero.js/core';
+import type { Dinero, MaximumParams } from '@dinero.js/core';
 
 /**
  * Get the greatest of the passed Dinero objects.
@@ -10,7 +10,9 @@ import type { MaximumParams } from '@dinero.js/core';
  *
  * @public
  */
-export function maximum<TAmount>(...[dineroObjects]: MaximumParams<TAmount>) {
+export function maximum<TAmount>(
+  ...[dineroObjects]: MaximumParams<TAmount>
+): Dinero<TAmount> {
   const { calculator } = dineroObjects[0];
   const maximumFn = safeMaximum(calculator);
 

--- a/packages/dinero.js/src/api/minimum.ts
+++ b/packages/dinero.js/src/api/minimum.ts
@@ -1,5 +1,5 @@
 import { safeMinimum } from '@dinero.js/core';
-import type { MinimumParams } from '@dinero.js/core';
+import type { Dinero, MinimumParams } from '@dinero.js/core';
 
 /**
  * Get the lowest of the passed Dinero objects.
@@ -10,7 +10,9 @@ import type { MinimumParams } from '@dinero.js/core';
  *
  * @public
  */
-export function minimum<TAmount>(...[dineroObjects]: MinimumParams<TAmount>) {
+export function minimum<TAmount>(
+  ...[dineroObjects]: MinimumParams<TAmount>
+): Dinero<TAmount> {
   const { calculator } = dineroObjects[0];
   const minimumFn = safeMinimum(calculator);
 

--- a/packages/dinero.js/src/api/multiply.ts
+++ b/packages/dinero.js/src/api/multiply.ts
@@ -1,5 +1,5 @@
 import { multiply as coreMultiply } from '@dinero.js/core';
-import type { MultiplyParams } from '@dinero.js/core';
+import type { Dinero, MultiplyParams } from '@dinero.js/core';
 
 /**
  * Multiply the passed Dinero object.
@@ -13,7 +13,7 @@ import type { MultiplyParams } from '@dinero.js/core';
  */
 export function multiply<TAmount>(
   ...[multiplicand, multiplier]: MultiplyParams<TAmount>
-) {
+): Dinero<TAmount> {
   const { calculator } = multiplicand;
   const multiplyFn = coreMultiply(calculator);
 

--- a/packages/dinero.js/src/api/normalizeScale.ts
+++ b/packages/dinero.js/src/api/normalizeScale.ts
@@ -1,5 +1,5 @@
 import { normalizeScale as coreNormalizeScale } from '@dinero.js/core';
-import type { NormalizeScaleParams } from '@dinero.js/core';
+import type { Dinero, NormalizeScaleParams } from '@dinero.js/core';
 
 /**
  * Normalize a set of Dinero objects to the highest scale of the set.
@@ -12,7 +12,7 @@ import type { NormalizeScaleParams } from '@dinero.js/core';
  */
 export function normalizeScale<TAmount>(
   ...[dineroObjects]: NormalizeScaleParams<TAmount>
-) {
+): ReadonlyArray<Dinero<TAmount>> {
   const { calculator } = dineroObjects[0];
   const normalizeScaleFn = coreNormalizeScale(calculator);
 

--- a/packages/dinero.js/src/api/subtract.ts
+++ b/packages/dinero.js/src/api/subtract.ts
@@ -1,5 +1,5 @@
 import { safeSubtract } from '@dinero.js/core';
-import type { SubtractParams } from '@dinero.js/core';
+import type { Dinero, SubtractParams } from '@dinero.js/core';
 
 /**
  * Subtract the passed Dinero objects.
@@ -13,7 +13,7 @@ import type { SubtractParams } from '@dinero.js/core';
  */
 export function subtract<TAmount>(
   ...[minuend, subtrahend]: SubtractParams<TAmount>
-) {
+): Dinero<TAmount> {
   const { calculator } = minuend;
   const subtractFn = safeSubtract(calculator);
 

--- a/packages/dinero.js/src/api/toDecimal.ts
+++ b/packages/dinero.js/src/api/toDecimal.ts
@@ -20,7 +20,7 @@ export function toDecimal<TAmount, TOutput>(
  */
 export function toDecimal<TAmount, TOutput>(
   ...[dineroObject, transformer]: ToDecimalParams<TAmount, TOutput>
-) {
+): TOutput | string {
   const { calculator } = dineroObject;
   const toDecimalFn = coreToDecimal<TAmount, TOutput>(calculator);
 

--- a/packages/dinero.js/src/api/toUnits.ts
+++ b/packages/dinero.js/src/api/toUnits.ts
@@ -22,7 +22,7 @@ export function toUnits<TAmount, TOutput>(
  */
 export function toUnits<TAmount, TOutput>(
   ...[dineroObject, transformer]: ToUnitsParams<TAmount, TOutput>
-) {
+): TOutput | readonly TAmount[] {
   const { calculator } = dineroObject;
   const toUnitsFn = coreToUnits<TAmount, TOutput>(calculator);
 

--- a/packages/dinero.js/src/api/transformScale.ts
+++ b/packages/dinero.js/src/api/transformScale.ts
@@ -1,5 +1,5 @@
 import { transformScale as coreTransformScale } from '@dinero.js/core';
-import type { TransformScaleParams } from '@dinero.js/core';
+import type { Dinero, TransformScaleParams } from '@dinero.js/core';
 
 /**
  * Transform a Dinero object to a new scale.
@@ -14,7 +14,7 @@ import type { TransformScaleParams } from '@dinero.js/core';
  */
 export function transformScale<TAmount>(
   ...[dineroObject, newScale, divide]: TransformScaleParams<TAmount>
-) {
+): Dinero<TAmount> {
   const { calculator } = dineroObject;
   const transformScaleFn = coreTransformScale(calculator);
 

--- a/packages/dinero.js/src/api/trimScale.ts
+++ b/packages/dinero.js/src/api/trimScale.ts
@@ -1,5 +1,5 @@
 import { trimScale as coreTrimScale } from '@dinero.js/core';
-import type { TrimScaleParams } from '@dinero.js/core';
+import type { Dinero, TrimScaleParams } from '@dinero.js/core';
 
 /**
  * Trim a Dinero object's scale as much as possible, down to the currency exponent.
@@ -12,7 +12,7 @@ import type { TrimScaleParams } from '@dinero.js/core';
  */
 export function trimScale<TAmount>(
   ...[dineroObject]: TrimScaleParams<TAmount>
-) {
+): Dinero<TAmount> {
   const { calculator } = dineroObject;
   const trimScaleFn = coreTrimScale(calculator);
 


### PR DESCRIPTION
Fixes #681.

Hi, @sarahdayan, Victor here. I came across the aforementioned issue where you requested explicit return types for functions. I have implemented the necessary changes and added the required types.

Here’s a summary of the updates:

- **Added explicit return types**: I explicitly defined return types for all functions as required.
- **Disabled ESLint check in `assert.ts`**: In `/dinero.js/packages/core/src/helpers/assert.ts`, I disabled the ESLint check for the void return type since it was causing errors.
**Handled undefined `scale` values**: I added default value settings for instances where the ScaledAmount type was initialized with a potentially undefined scale value.

I used VSCode's built-in Refactor feature to generate the return types and manually correct any errors that arose during the process.

Let me know if you need any further adjustments!