### PR TITLE
chore: release v2.0.0-alpha.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# [2.0.0-alpha.15](https://github.com/dinerojs/dinero.js/compare/v2.0.0-alpha.14...v2.0.0-alpha.15) (2025-01-29)
+
+
+### Bug Fixes
+
+* **allocate:** distribute remainder to largest ratio first ([#776](https://github.com/dinerojs/dinero.js/issues/776)) ([6049038](https://github.com/dinerojs/dinero.js/commit/60490387))
+* **allocate:** prevent infinite loop with large amounts ([#771](https://github.com/dinerojs/dinero.js/issues/771)) ([d787b98](https://github.com/dinerojs/dinero.js/commit/d787b988))
+* **toDecimal:** do not append decimal string when scale is zero ([#751](https://github.com/dinerojs/dinero.js/issues/751)) ([80a1dd7](https://github.com/dinerojs/dinero.js/commit/80a1dd7c))
+
+
+
 # [2.0.0-alpha.14](https://github.com/dinerojs/dinero.js/compare/v2.0.0-alpha.13...v2.0.0-alpha.14) (2023-02-27)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dinero.js/monorepo",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-alpha.15",
   "private": true,
   "license": "MIT",
   "workspaces": [

--- a/packages/calculator-bigint/package.json
+++ b/packages/calculator-bigint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dinero.js/calculator-bigint",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-alpha.15",
   "description": "Bigint calculator implementation for Dinero.js",
   "keywords": [
     "money",
@@ -29,7 +29,9 @@
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
@@ -40,6 +42,6 @@
     "test": "node ../../scripts/test.mjs --projects=./packages/calculator-bigint"
   },
   "dependencies": {
-    "@dinero.js/core": "2.0.0-alpha.14"
+    "@dinero.js/core": "2.0.0-alpha.15"
   }
 }

--- a/packages/calculator-number/package.json
+++ b/packages/calculator-number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dinero.js/calculator-number",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-alpha.15",
   "description": "Number calculator implementation for Dinero.js",
   "keywords": [
     "money",
@@ -29,7 +29,9 @@
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
@@ -40,6 +42,6 @@
     "test": "node ../../scripts/test.mjs --projects=./packages/calculator-number"
   },
   "dependencies": {
-    "@dinero.js/core": "2.0.0-alpha.14"
+    "@dinero.js/core": "2.0.0-alpha.15"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@dinero.js/core",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-alpha.15",
   "description": "Common code between Dinero.js packages",
-  "keywords": ["money", "monetary", "amount", "immutable"],
+  "keywords": [
+    "money",
+    "monetary",
+    "amount",
+    "immutable"
+  ],
   "homepage": "https://v2.dinerojs.com",
   "bugs": "https://github.com/dinerojs/dinero.js/issues",
   "repository": {
@@ -22,7 +27,9 @@
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
@@ -33,6 +40,6 @@
     "test": "node ../../scripts/test.mjs --projects=./packages/core"
   },
   "dependencies": {
-    "@dinero.js/currencies": "2.0.0-alpha.14"
+    "@dinero.js/currencies": "2.0.0-alpha.15"
   }
 }

--- a/packages/currencies/package.json
+++ b/packages/currencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dinero.js/currencies",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-alpha.15",
   "description": "Common currency implementations for Dinero.js",
   "keywords": [
     "money",

--- a/packages/dinero.js/package.json
+++ b/packages/dinero.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dinero.js",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-alpha.15",
   "description": "Create, calculate, and format money in JavaScript and TypeScript",
   "keywords": [
     "money",
@@ -29,7 +29,9 @@
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build:clean": "rimraf ./{dist,temp}",
     "build:esm": "babel src --root-mode upward --extensions '.ts' --out-dir dist/esm --ignore '**/*/__tests__/'",
@@ -40,11 +42,11 @@
     "test": "node ../../scripts/test.mjs --projects=./packages/dinero.js"
   },
   "dependencies": {
-    "@dinero.js/calculator-number": "2.0.0-alpha.14",
-    "@dinero.js/core": "2.0.0-alpha.14",
-    "@dinero.js/currencies": "2.0.0-alpha.14"
+    "@dinero.js/calculator-number": "2.0.0-alpha.15",
+    "@dinero.js/core": "2.0.0-alpha.15",
+    "@dinero.js/currencies": "2.0.0-alpha.15"
   },
   "devDependencies": {
-    "@dinero.js/calculator-bigint": "2.0.0-alpha.14"
+    "@dinero.js/calculator-bigint": "2.0.0-alpha.15"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dinero.js/website",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-alpha.15",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,11 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@dinero.js/currencies": "2.0.0-alpha.14",
+    "@dinero.js/currencies": "2.0.0-alpha.15",
     "@docsearch/css": "3.2.1",
     "@docsearch/react": "3.3.0",
     "classnames": "2.3.2",
-    "dinero.js": "2.0.0-alpha.14",
+    "dinero.js": "2.0.0-alpha.15",
     "fathom-client": "3.5.0",
     "github-slugger": "1.4.0",
     "next": "13.0.2",


### PR DESCRIPTION
## Summary

This release includes critical bug fixes for the allocation algorithm:

- **fix(allocate): distribute remainder to largest ratio first** (#776)
  - The allocation algorithm now correctly gives remainder to the partition with the largest ratio instead of the first partition
  
- **fix(allocate): prevent infinite loop with large amounts** (#771)
  - Fixed an issue where `allocate()` could hang with amounts larger than `Number.MAX_SAFE_INTEGER` due to floating-point precision loss
  
- **fix(toDecimal): do not append decimal string when scale is zero** (#751)
  - `toDecimal()` now returns integers correctly for zero-scale currencies (e.g., JPY)

## Checklist

- [x] Tests pass
- [x] Type check passes
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.ai/code)