### PR TITLE
ci: skip prepare script in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build packages
         run: npm run build
@@ -62,7 +62,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -88,7 +88,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -114,7 +114,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -140,7 +140,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -172,7 +172,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to all `npm ci` calls in release.yml
- Same optimization as applied to ci.yml in #816