### PR TITLE
docs: clarify immutability in Quick Start examples

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -48,16 +48,19 @@ const price = dinero({ amount: 5000, currency: USD });
 You can add or subtract any amount you want, by passing it another Dinero object:
 
 ```js
-import { dinero, add, subtract } from 'dinero.js';
+import { dinero, add, subtract, toDecimal } from 'dinero.js';
 import { USD } from 'dinero.js/currencies';
 
 const price = dinero({ amount: 5000, currency: USD });
 
 // returns a Dinero object with amount 6000
-add(price, dinero({ amount: 1000, currency: USD }));
+const priceWithShipping = add(price, dinero({ amount: 1000, currency: USD }));
 
 // returns a Dinero object with amount 4000
-subtract(price, dinero({ amount: 1000, currency: USD }));
+const priceWithDiscount = subtract(price, dinero({ amount: 1000, currency: USD }));
+
+// base variable `price` is immutable
+console.log(toDecimal(price)) // output : 50.00
 ```
 
 Dinero objects are immutable, meaning you always get a new Dinero object when performing transformations. Your original objects remain untouched.


### PR DESCRIPTION
## Description
The current examples in the "Quick start" section could be misleading for developers new to functional programming. Since Dinero objects are immutable, operations like `add()` and `subtract()` do not mutate the original object but return a new one.

In the previous version of the documentation, the examples performed operations without assigning them to variables, which might lead a reader to believe that the `price` variable was being updated or that operations were chained.

## Changes
- Assigned `add()` and `subtract()` results to descriptive variables (`priceWithShipping`, `priceWithDiscount`).
- Added a `toDecimal()` call to explicitly demonstrate that the original `price` object remains unchanged (immutability).
- Included `toDecimal` in the imports to make the example fully functional for copy-pasting.

## Modified Code Snippet
```js
import { dinero, add, subtract, toDecimal } from 'dinero.js';
import { USD } from 'dinero.js/currencies';

const price = dinero({ amount: 5000, currency: USD });

// returns a new Dinero object with amount 6000
const priceWithShipping = add(price, dinero({ amount: 1000, currency: USD }));

// returns a new Dinero object with amount 4000
const priceWithDiscount = subtract(price, dinero({ amount: 1000, currency: USD }));

// base variable `price` remains immutable and untouched
console.log(toDecimal(price)); // "50.00"