### PR TITLE
docs: prioritize user-supplied scale in dineroFromFloat example

### DIFF
--- a/docs/guides/creating-from-floats.md
+++ b/docs/guides/creating-from-floats.md
@@ -18,7 +18,7 @@ If you have amounts as floats (in this case, `19.99`) and you want to abstract o
 
 ```js
 function dineroFromFloat({ amount: float, currency, scale }) {
-  const factor = currency.base ** (currency.exponent || scale);
+  const factor = currency.base ** (scale ?? currency.exponent);
   const amount = Math.round(float * factor);
 
   return dinero({ amount, currency, scale });


### PR DESCRIPTION
## Summary

- Fixed the `dineroFromFloat` example in the "Creating from floats" guide to prioritize user-supplied `scale` over `currency.exponent`
- Changed `currency.base ** (currency.exponent || scale)` to `currency.base ** (scale ?? currency.exponent)`

Fixes #761