### PR TITLE
chore(examples): deploy all examples on Vercel

### DIFF
--- a/docs/build-examples.sh
+++ b/docs/build-examples.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+DOCS_DIST="$(cd "$(dirname "$0")/.vitepress/dist" && pwd)"
+EXAMPLES_DIR="$(cd "$(dirname "$0")/../examples" && pwd)"
+
+for example in cart-react cart-vue pricing-react expense-splitter starter; do
+  echo "Building $example..."
+  cd "$EXAMPLES_DIR/$example"
+  npm install
+  npm run build
+  mkdir -p "$DOCS_DIST/examples/$example"
+  cp -r dist/* "$DOCS_DIST/examples/$example"
+done

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -11,25 +11,25 @@ If you learn better by seeing code in action, or want to start from an existing 
 
 This demo showcases Dinero.js in action in a [React](https://reactjs.org/)-powered shopping cart.
 
-[![Shopping cart with React](/images/examples/cart-react.png)](https://codesandbox.io/s/github/dinerojs/dinero.js/tree/main/examples/cart-react)
+[![Shopping cart with React](/images/examples/cart-react.png)](https://v2.dinerojs.com/examples/cart-react/)
 
-[View demo](https://codesandbox.io/s/github/dinerojs/dinero.js/tree/main/examples/cart-react)
+[View demo](https://v2.dinerojs.com/examples/cart-react/)
 
 ## Shopping cart with Vue.js
 
 This demo showcases Dinero.js in action in a [Vue.js](https://vuejs.org/)-powered shopping cart.
 
-[![Shopping cart with Vue.js](/images/examples/cart-vue.png)](https://codesandbox.io/s/github/dinerojs/dinero.js/tree/main/examples/cart-vue)
+[![Shopping cart with Vue.js](/images/examples/cart-vue.png)](https://v2.dinerojs.com/examples/cart-vue/)
 
-[View demo](https://codesandbox.io/s/github/dinerojs/dinero.js/tree/main/examples/cart-vue)
+[View demo](https://v2.dinerojs.com/examples/cart-vue/)
 
 ## Pricing page with React
 
 This demo showcases Dinero.js in action in a [React](https://reactjs.org/)-powered pricing page.
 
-[![Pricing page with React](/images/examples/pricing-react.png)](https://codesandbox.io/s/github/dinerojs/dinero.js/tree/main/examples/pricing-react)
+[![Pricing page with React](/images/examples/pricing-react.png)](https://v2.dinerojs.com/examples/pricing-react/)
 
-[View demo](https://codesandbox.io/s/github/dinerojs/dinero.js/tree/main/examples/pricing-react)
+[View demo](https://v2.dinerojs.com/examples/pricing-react/)
 
 ## Expense splitter
 
@@ -41,6 +41,6 @@ This demo showcases Dinero.js in action in a [React](https://reactjs.org/)-power
 
 This demo lets you try Dinero.js in a minimal environment. It's ideal to reproduce issues.
 
-[![Starter playground](/images/examples/starter.png)](https://codesandbox.io/s/github/dinerojs/dinero.js/tree/main/examples/starter)
+[![Starter playground](/images/examples/starter.png)](https://v2.dinerojs.com/examples/starter/)
 
-[View demo](https://codesandbox.io/s/github/dinerojs/dinero.js/tree/main/examples/starter)
+[View demo](https://v2.dinerojs.com/examples/starter/)

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npx vitepress build && cd ../examples/expense-splitter && npm install && npm run build && mkdir -p ../../docs/.vitepress/dist/examples/expense-splitter && cp -r dist/* ../../docs/.vitepress/dist/examples/expense-splitter",
+  "buildCommand": "npx vitepress build && bash build-examples.sh",
   "outputDirectory": ".vitepress/dist",
   "redirects": [
     {

--- a/examples/cart-react/vite.config.js
+++ b/examples/cart-react/vite.config.js
@@ -3,5 +3,6 @@ import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/examples/cart-react/',
   plugins: [react()],
 });

--- a/examples/cart-vue/vite.config.js
+++ b/examples/cart-vue/vite.config.js
@@ -3,5 +3,6 @@ import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/examples/cart-vue/',
   plugins: [vue()],
 });

--- a/examples/pricing-react/package.json
+++ b/examples/pricing-react/package.json
@@ -8,6 +8,7 @@
     "serve": "vite preview"
   },
   "dependencies": {
+    "@babel/runtime": "^7.28.6",
     "@heroicons/react": "^2.2.0",
     "classnames": "^2.5.0",
     "dinero.js": "2.0.0-alpha.16",

--- a/examples/pricing-react/vite.config.js
+++ b/examples/pricing-react/vite.config.js
@@ -3,5 +3,6 @@ import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/examples/pricing-react/',
   plugins: [react()],
 });

--- a/examples/starter/vite.config.js
+++ b/examples/starter/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: '/examples/starter/',
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1792,6 +1792,7 @@
       "name": "@dinero.js/example-pricing-react",
       "version": "2.0.0-alpha.16",
       "dependencies": {
+        "@babel/runtime": "^7.28.6",
         "@heroicons/react": "^2.2.0",
         "classnames": "^2.5.0",
         "dinero.js": "2.0.0-alpha.16",
@@ -3453,6 +3454,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {


### PR DESCRIPTION
## Summary

- Add Vite `base` paths to all example projects so assets resolve correctly when served from `/examples/<name>/`
- Extract the example build logic into `docs/build-examples.sh` to keep the Vercel build command clean
- Update demo links from CodeSandbox to `v2.dinerojs.com/examples/<name>/`
- Fix missing `@babel/runtime` dependency in pricing-react