### PR TITLE
feat: add compile-time currency safety with `TCurrency` type parameter

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -133,6 +133,10 @@ export default defineConfig({
               link: '/guides/precision-and-large-numbers',
             },
             {
+              text: 'Currency type safety',
+              link: '/guides/currency-type-safety',
+            },
+            {
               text: 'Serialization',
               link: '/guides/transporting-and-restoring',
             },

--- a/docs/.vitepress/theme/HomeFeatures.vue
+++ b/docs/.vitepress/theme/HomeFeatures.vue
@@ -13,7 +13,7 @@ const features = [
   {
     title: 'Multi-currency',
     details:
-      'Built-in support for ISO 4217 currencies and custom currency definitions.',
+      'Built-in ISO 4217 currencies with compile-time safety to catch mismatches.',
   },
   {
     title: 'Tree-shakeable',

--- a/docs/api/comparisons/compare.md
+++ b/docs/api/comparisons/compare.md
@@ -15,12 +15,14 @@ Possible return values are:
 
 **You can only compare objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before comparing them.
 
+In TypeScript, this is enforced at compile time when using [typed currencies](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The first Dinero object to compare. | Yes |
-| `comparator` | `Dinero<TAmount>` | The second Dinero object to compare. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The first Dinero object to compare. | Yes |
+| `comparator` | `Dinero<TAmount, TCurrency>` | The second Dinero object to compare. | Yes |
 
 ## Code examples
 

--- a/docs/api/comparisons/equal.md
+++ b/docs/api/comparisons/equal.md
@@ -14,8 +14,8 @@ This function does same-value equality, determining whether two Dinero objects a
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The first Dinero object to compare. | Yes |
-| `comparator` | `Dinero<TAmount>` | The second Dinero object to compare. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The first Dinero object to compare. | Yes |
+| `comparator` | `Dinero<TAmount, TCurrency>` | The second Dinero object to compare. | Yes |
 
 ## Code examples
 

--- a/docs/api/comparisons/greater-than-or-equal.md
+++ b/docs/api/comparisons/greater-than-or-equal.md
@@ -10,12 +10,14 @@ Check whether the value of a Dinero object is greater than or equal another.
 
 **You can only compare objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before comparing them.
 
+In TypeScript, this is enforced at compile time when using [typed currencies](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The first Dinero object to compare. | Yes |
-| `comparator` | `Dinero<TAmount>` | The second Dinero object to compare. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The first Dinero object to compare. | Yes |
+| `comparator` | `Dinero<TAmount, TCurrency>` | The second Dinero object to compare. | Yes |
 
 ## Code examples
 

--- a/docs/api/comparisons/greater-than.md
+++ b/docs/api/comparisons/greater-than.md
@@ -10,12 +10,14 @@ Check whether the value of a Dinero object is greater than another.
 
 **You can only compare objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before comparing them.
 
+In TypeScript, this is enforced at compile time when using [typed currencies](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The first Dinero object to compare. | Yes |
-| `comparator` | `Dinero<TAmount>` | The second Dinero object to compare. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The first Dinero object to compare. | Yes |
+| `comparator` | `Dinero<TAmount, TCurrency>` | The second Dinero object to compare. | Yes |
 
 ## Code examples
 

--- a/docs/api/comparisons/have-same-amount.md
+++ b/docs/api/comparisons/have-same-amount.md
@@ -12,7 +12,7 @@ Check whether a set of Dinero objects have the same amount.
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObjects` | `Dinero<TAmount>[]` | The Dinero object to check. | Yes |
+| `dineroObjects` | `Dinero<TAmount, TCurrency>[]` | The Dinero object to check. | Yes |
 
 ## Code examples
 

--- a/docs/api/comparisons/less-than-or-equal.md
+++ b/docs/api/comparisons/less-than-or-equal.md
@@ -10,12 +10,14 @@ Check whether the value of a Dinero object is lesser than or equal to another.
 
 **You can only compare objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before comparing them.
 
+In TypeScript, this is enforced at compile time when using [typed currencies](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The first Dinero object to compare. | Yes |
-| `comparator` | `Dinero<TAmount>` | The second Dinero object to compare. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The first Dinero object to compare. | Yes |
+| `comparator` | `Dinero<TAmount, TCurrency>` | The second Dinero object to compare. | Yes |
 
 ## Code examples
 

--- a/docs/api/comparisons/less-than.md
+++ b/docs/api/comparisons/less-than.md
@@ -10,12 +10,14 @@ Check whether the value of a Dinero object is lesser than another.
 
 **You can only compare objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before comparing them.
 
+In TypeScript, this is enforced at compile time when using [typed currencies](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The first Dinero object to compare. | Yes |
-| `comparator` | `Dinero<TAmount>` | The second Dinero object to compare. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The first Dinero object to compare. | Yes |
+| `comparator` | `Dinero<TAmount, TCurrency>` | The second Dinero object to compare. | Yes |
 
 ## Code examples
 

--- a/docs/api/comparisons/maximum.md
+++ b/docs/api/comparisons/maximum.md
@@ -1,7 +1,7 @@
 ---
 title: maximum
 description: Get the greatest of the passed Dinero objects.
-returns: Dinero<TAmount>
+returns: Dinero<TAmount, TCurrency>
 ---
 
 # maximum
@@ -10,11 +10,13 @@ Get the greatest of the passed Dinero objects.
 
 **You can only compare objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before comparing them.
 
+In TypeScript, this is enforced at compile time when using [typed currencies](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObjects` | `Dinero<TAmount>[]` | The Dinero objects to maximum. | Yes |
+| `dineroObjects` | `Dinero<TAmount, TCurrency>[]` | The Dinero objects to maximum. | Yes |
 
 ## Code examples
 

--- a/docs/api/comparisons/minimum.md
+++ b/docs/api/comparisons/minimum.md
@@ -1,7 +1,7 @@
 ---
 title: minimum
 description: Get the lowest of the passed Dinero objects.
-returns: Dinero<TAmount>
+returns: Dinero<TAmount, TCurrency>
 ---
 
 # minimum
@@ -10,11 +10,13 @@ Get the lowest of the passed Dinero objects.
 
 **You can only compare objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before comparing them.
 
+In TypeScript, this is enforced at compile time when using [typed currencies](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObjects` | `Dinero<TAmount>[]` | The Dinero objects to minimum. | Yes |
+| `dineroObjects` | `Dinero<TAmount, TCurrency>[]` | The Dinero objects to minimum. | Yes |
 
 ## Code examples
 

--- a/docs/api/conversions/convert.md
+++ b/docs/api/conversions/convert.md
@@ -1,7 +1,7 @@
 ---
 title: convert
 description: Create a Dinero object converter.
-returns: Dinero<TAmount>
+returns: Dinero<TAmount, TNewCurrency>
 ---
 
 # convert
@@ -10,12 +10,14 @@ Convert a Dinero object from a currency to another.
 
 If you need to use fractional rates, you shouldn't use floats, but scaled amounts instead. For example, instead of passing `0.89`, you should pass `{ amount: 89, scale: 2 }`. When using scaled amounts, the function converts the returned object to the safest scale.
 
+In TypeScript, the returned Dinero object carries the type of the new currency. See [Currency type safety](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The Dinero object to convert. | Yes |
-| `newCurrency` | `Currency<TAmount>` | The currency to convert into. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The Dinero object to convert. | Yes |
+| `newCurrency` | `Currency<TAmount, TNewCurrency>` | The currency to convert into. | Yes |
 | `rates` | `Rates<TAmount>` | The rates to convert with. | Yes |
 
 ## Code examples

--- a/docs/api/conversions/normalize-scale.md
+++ b/docs/api/conversions/normalize-scale.md
@@ -1,7 +1,7 @@
 ---
 title: normalizeScale
 description: Normalize a set of Dinero objects to the highest scale of the set.
-returns: Dinero<TAmount>[]
+returns: Dinero<TAmount, TCurrency>[]
 ---
 
 # normalizeScale
@@ -14,7 +14,7 @@ Normalizing to a higher scale means that the internal `amount` value increases b
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObjects` | `Dinero<TAmount>[]` | The Dinero objects to normalize. | Yes |
+| `dineroObjects` | `Dinero<TAmount, TCurrency>[]` | The Dinero objects to normalize. | Yes |
 
 ## Code examples
 

--- a/docs/api/conversions/transform-scale.md
+++ b/docs/api/conversions/transform-scale.md
@@ -1,7 +1,7 @@
 ---
 title: transformScale
 description: Transform a Dinero object to a new scale.
-returns: Dinero<TAmount>
+returns: Dinero<TAmount, TCurrency>
 ---
 
 # transformScale
@@ -18,7 +18,7 @@ For convenience, Dinero.js provides the following divide functions: `up`, `down`
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The Dinero object to transform. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The Dinero object to transform. | Yes |
 | `newScale` | `TAmount` | The new scale. | Yes |
 | `divide` | `DivideOperation` | A custom divide function. | No |
 

--- a/docs/api/conversions/trim-scale.md
+++ b/docs/api/conversions/trim-scale.md
@@ -1,7 +1,7 @@
 ---
 title: trimScale
 description: Trim a Dinero object's scale as much as possible, down to the currency exponent.
-returns: Dinero<TAmount>
+returns: Dinero<TAmount, TCurrency>
 ---
 
 # trimScale
@@ -12,7 +12,7 @@ Trim a Dinero object's scale as much as possible, down to the currency exponent.
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The Dinero object to trim. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The Dinero object to trim. | Yes |
 
 ## Code examples
 

--- a/docs/api/formatting/to-decimal.md
+++ b/docs/api/formatting/to-decimal.md
@@ -18,8 +18,8 @@ You can only use this function with Dinero objects that are single-based and use
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The Dinero object to format. | Yes |
-| `transformer` | `Transformer<TAmount, TOutput>` | An optional transformer function. | No |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The Dinero object to format. | Yes |
+| `transformer` | `Transformer<TAmount, TOutput, TCurrency>` | An optional transformer function. | No |
 
 ## Code examples
 

--- a/docs/api/formatting/to-snapshot.md
+++ b/docs/api/formatting/to-snapshot.md
@@ -1,7 +1,7 @@
 ---
 title: toSnapshot
 description: Get a snapshot of a Dinero object.
-returns: DineroSnapshot<TAmount>
+returns: DineroSnapshot<TAmount, TCurrency>
 ---
 
 # toSnapshot
@@ -14,7 +14,7 @@ Snapshots are plain JavaScript objects, suited for [transport and storage](/guid
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The Dinero object to snapshot. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The Dinero object to snapshot. | Yes |
 
 ## Code examples
 

--- a/docs/api/formatting/to-units.md
+++ b/docs/api/formatting/to-units.md
@@ -16,8 +16,8 @@ When specifying multiple bases, the function returns as many units as necessary.
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The Dinero object to format. | Yes |
-| `transformer` | `Transformer<TAmount, TOutput>` | An optional transformer function. | No |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The Dinero object to format. | Yes |
+| `transformer` | `Transformer<TAmount, TOutput, TCurrency>` | An optional transformer function. | No |
 
 ## Code examples
 

--- a/docs/api/mutations/add.md
+++ b/docs/api/mutations/add.md
@@ -1,7 +1,7 @@
 ---
 title: add
 description: Adding up two Dinero objects.
-returns: Dinero<TAmount>
+returns: Dinero<TAmount, TCurrency>
 ---
 
 # add
@@ -10,12 +10,14 @@ Add up two Dinero objects.
 
 **You can only add objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before adding them up.
 
+In TypeScript, this is enforced at compile time when using [typed currencies](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `augend` | `Dinero<TAmount>` | The Dinero object to add to. | Yes |
-| `addend` | `Dinero<TAmount>` | The Dinero object to add. | Yes |
+| `augend` | `Dinero<TAmount, TCurrency>` | The Dinero object to add to. | Yes |
+| `addend` | `Dinero<TAmount, TCurrency>` | The Dinero object to add. | Yes |
 
 ## Code examples
 

--- a/docs/api/mutations/allocate.md
+++ b/docs/api/mutations/allocate.md
@@ -1,7 +1,7 @@
 ---
 title: allocate
 description: Distribute the amount of a Dinero object across a list of ratios.
-returns: Dinero<TAmount>[]
+returns: Dinero<TAmount, TCurrency>[]
 ---
 
 # allocate
@@ -20,7 +20,7 @@ If you need to use fractional ratios, you shouldn't use floats, but scaled amoun
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `dineroObject` | `Dinero<TAmount>` | The Dinero object to allocate from. | Yes |
+| `dineroObject` | `Dinero<TAmount, TCurrency>` | The Dinero object to allocate from. | Yes |
 | `ratios` | `Array<ScaledAmount<TAmount> \| TAmount>` | The ratios to allocate the amount to. | Yes |
 
 ## Code examples

--- a/docs/api/mutations/multiply.md
+++ b/docs/api/mutations/multiply.md
@@ -1,7 +1,7 @@
 ---
 title: multiply
 description: Multiply a Dinero object.
-returns: Dinero<TAmount>
+returns: Dinero<TAmount, TCurrency>
 ---
 
 # multiply
@@ -14,7 +14,7 @@ If you need to multiply by a fractional multiplier, you shouldn't use floats, bu
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `multiplicand` | `Dinero<TAmount>` | The Dinero object to multiply. | Yes |
+| `multiplicand` | `Dinero<TAmount, TCurrency>` | The Dinero object to multiply. | Yes |
 | `multiplier` | `ScaledAmount<TAmount> \| TAmount` | The number to multiply with. | Yes |
 
 ## Code examples

--- a/docs/api/mutations/subtract.md
+++ b/docs/api/mutations/subtract.md
@@ -1,7 +1,7 @@
 ---
 title: subtract
 description: Subtracting two Dinero objects.
-returns: Dinero<TAmount>
+returns: Dinero<TAmount, TCurrency>
 ---
 
 # subtract
@@ -10,12 +10,14 @@ Subtract two Dinero objects.
 
 **You can only subtract objects that share the same currency.** The function also normalizes objects to the same scale (the highest) before subtracting them.
 
+In TypeScript, this is enforced at compile time when using [typed currencies](/guides/currency-type-safety).
+
 ## Parameters
 
 | Name | Type | Description | Required |
 |------|------|-------------|----------|
-| `minuend` | `Dinero<TAmount>` | The Dinero object to subtract from. | Yes |
-| `subtrahend` | `Dinero<TAmount>` | The Dinero object to subtract. | Yes |
+| `minuend` | `Dinero<TAmount, TCurrency>` | The Dinero object to subtract from. | Yes |
+| `subtrahend` | `Dinero<TAmount, TCurrency>` | The Dinero object to subtract. | Yes |
 
 ## Code examples
 

--- a/docs/core-concepts/currency.md
+++ b/docs/core-concepts/currency.md
@@ -146,7 +146,7 @@ const FRF = {
 If you're a TypeScript user, you can implement the `Currency` type. It takes a generic parameter `TAmount` which represents the type you're using for numeric values (`number` by default).
 
 ```ts
-import { Currency } from 'dinero.js';
+import type { Currency } from 'dinero.js';
 
 const FRF: Currency<number> = {
   code: 'FRF',
@@ -155,6 +155,18 @@ const FRF: Currency<number> = {
 };
 ```
 
-If you want to use a different amount type, you'll need to pass a custom `Calculator` to Dinero.
+To opt into [compile-time currency safety](/guides/currency-type-safety), use `as const satisfies` to preserve the literal type of the currency code:
 
-**See also:** [Precision and large numbers](/guides/precision-and-large-numbers)
+```ts
+import type { Currency } from 'dinero.js';
+
+const FRF = {
+  code: 'FRF',
+  base: 10,
+  exponent: 2,
+} as const satisfies Currency<number, 'FRF'>;
+```
+
+This lets TypeScript catch currency mismatches (e.g., adding USD and EUR) at compile time. The built-in ISO 4217 currencies are already typed this way.
+
+**See also:** [Currency type safety](/guides/currency-type-safety), [Precision and large numbers](/guides/precision-and-large-numbers)

--- a/docs/guides/currency-type-safety.md
+++ b/docs/guides/currency-type-safety.md
@@ -1,0 +1,112 @@
+---
+title: Currency type safety
+description: Catch currency mismatches at compile time with TypeScript.
+---
+
+# Currency type safety
+
+If you're using TypeScript, Dinero.js can catch currency mismatches at compile time. When you use the built-in ISO 4217 currencies, operations like `add`, `subtract`, or `equal` will reject Dinero objects of different currencies before your code even runs.
+
+## How it works
+
+Every Dinero object carries a `TCurrency` type parameter that represents its currency code as a string literal type. When you use a built-in currency like `USD`, the Dinero object is typed as `Dinero<number, 'USD'>`. Operations that require the same currency enforce this at the type level.
+
+```ts
+import { dinero, add } from 'dinero.js';
+import { USD, EUR } from 'dinero.js/currencies';
+
+const d1 = dinero({ amount: 500, currency: USD }); // Dinero<number, 'USD'>
+const d2 = dinero({ amount: 100, currency: USD }); // Dinero<number, 'USD'>
+const d3 = dinero({ amount: 100, currency: EUR }); // Dinero<number, 'EUR'>
+
+add(d1, d2); // OK
+add(d1, d3); // Type error: 'EUR' is not assignable to 'USD'
+```
+
+This applies to all operations that expect the same currency: `add`, `subtract`, `equal`, `compare`, `greaterThan`, `greaterThanOrEqual`, `lessThan`, `lessThanOrEqual`, `minimum`, `maximum`, `haveSameAmount`, and `normalizeScale`.
+
+## Preserved through operations
+
+The currency type is preserved through unary operations. When you `multiply`, `allocate`, `trimScale`, or `transformScale` a Dinero object, the result keeps the same currency type.
+
+```ts
+import { dinero, add, multiply, allocate } from 'dinero.js';
+import { USD, EUR } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1000, currency: USD });
+
+const doubled = multiply(price, 2); // Dinero<number, 'USD'>
+add(doubled, price); // OK
+add(doubled, dinero({ amount: 100, currency: EUR })); // Type error
+
+const [half1, half2] = allocate(price, [50, 50]); // Dinero<number, 'USD'>[]
+add(half1, price); // OK
+```
+
+## Currency conversion
+
+When you `convert` a Dinero object, the result takes the type of the target currency.
+
+```ts
+import { dinero, add, convert } from 'dinero.js';
+import { USD, EUR } from 'dinero.js/currencies';
+
+const d = dinero({ amount: 500, currency: USD }); // Dinero<number, 'USD'>
+
+const rates = { EUR: { amount: 89, scale: 2 } };
+const converted = convert(d, EUR, rates); // Dinero<number, 'EUR'>
+
+add(converted, dinero({ amount: 100, currency: EUR })); // OK
+add(converted, d); // Type error: 'USD' is not assignable to 'EUR'
+```
+
+## Typed snapshots and formatters
+
+The currency type flows through to snapshots and formatter callbacks.
+
+```ts
+import { dinero, toSnapshot, toDecimal } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const d = dinero({ amount: 1050, currency: USD });
+
+const snapshot = toSnapshot(d);
+snapshot.currency.code; // type is 'USD', not string
+
+toDecimal(d, ({ currency }) => {
+  currency.code; // type is 'USD', not string
+  return `${currency.code} ...`;
+});
+```
+
+## Custom currencies
+
+If you define custom currencies, you can opt into currency type safety by using `as const satisfies`:
+
+```ts
+import type { Currency } from 'dinero.js';
+
+const BTC = {
+  code: 'BTC',
+  base: 10,
+  exponent: 8,
+} as const satisfies Currency<number, 'BTC'>;
+```
+
+The `as const` gives the `code` field the literal type `'BTC'` instead of `string`, and `satisfies` validates the object conforms to the `Currency` shape.
+
+Without `as const`, the currency code is inferred as `string`, and Dinero objects using it won't enforce currency matching. This is intentional: it keeps Dinero.js backward compatible and lets you opt into stricter checking only when you want it.
+
+## Backward compatibility
+
+The `TCurrency` type parameter defaults to `string`. Existing code that doesn't use typed currencies continues to work without changes.
+
+```ts
+// These are both Dinero<number, string> — no type enforcement
+const currency = { code: 'USD', base: 10, exponent: 2 };
+const d1 = dinero({ amount: 500, currency });
+const d2 = dinero({ amount: 100, currency });
+add(d1, d2); // OK — both are string-typed
+```
+
+Runtime currency checks (`haveSameCurrency` assertions) remain active regardless of typing, so JavaScript users and defensive programming patterns still work.

--- a/packages/dinero.js/src/__tests__/currency-safety.typetest.ts
+++ b/packages/dinero.js/src/__tests__/currency-safety.typetest.ts
@@ -1,0 +1,175 @@
+/**
+ * Type-level tests for currency safety.
+ *
+ * These tests don't run at runtime. They are validated by `npm run test:types`.
+ * Lines marked with `@ts-expect-error` must produce a type error.
+ * If they don't, tsc will report an "unused @ts-expect-error" error, failing
+ * the type check.
+ */
+
+import { USD, EUR } from 'dinero.js/currencies';
+
+import {
+  dinero,
+  add,
+  subtract,
+  greaterThan,
+  greaterThanOrEqual,
+  lessThan,
+  lessThanOrEqual,
+  equal,
+  compare,
+  minimum,
+  maximum,
+  haveSameAmount,
+  normalizeScale,
+  allocate,
+  multiply,
+  trimScale,
+  transformScale,
+  convert,
+  toSnapshot,
+  toDecimal,
+  toUnits,
+  haveSameCurrency,
+} from 'dinero.js';
+
+const dineroUSD = dinero({ amount: 1000, currency: USD });
+const dineroEUR = dinero({ amount: 1000, currency: EUR });
+
+/**
+ * Same-currency operations should compile
+ */
+
+add(dineroUSD, dineroUSD);
+subtract(dineroUSD, dineroUSD);
+greaterThan(dineroUSD, dineroUSD);
+greaterThanOrEqual(dineroUSD, dineroUSD);
+lessThan(dineroUSD, dineroUSD);
+lessThanOrEqual(dineroUSD, dineroUSD);
+equal(dineroUSD, dineroUSD);
+compare(dineroUSD, dineroUSD);
+minimum([dineroUSD, dineroUSD]);
+maximum([dineroUSD, dineroUSD]);
+haveSameAmount([dineroUSD, dineroUSD]);
+normalizeScale([dineroUSD, dineroUSD]);
+
+/**
+ * Cross-currency operations should NOT compile
+ */
+
+// @ts-expect-error - Different currencies
+add(dineroUSD, dineroEUR);
+
+// @ts-expect-error - Different currencies
+subtract(dineroUSD, dineroEUR);
+
+// @ts-expect-error - Different currencies
+greaterThan(dineroUSD, dineroEUR);
+
+// @ts-expect-error - Different currencies
+greaterThanOrEqual(dineroUSD, dineroEUR);
+
+// @ts-expect-error - Different currencies
+lessThan(dineroUSD, dineroEUR);
+
+// @ts-expect-error - Different currencies
+lessThanOrEqual(dineroUSD, dineroEUR);
+
+// @ts-expect-error - Different currencies
+equal(dineroUSD, dineroEUR);
+
+// @ts-expect-error - Different currencies
+compare(dineroUSD, dineroEUR);
+
+// @ts-expect-error - Different currencies
+minimum([dineroUSD, dineroEUR]);
+
+// @ts-expect-error - Different currencies
+maximum([dineroUSD, dineroEUR]);
+
+// @ts-expect-error - Different currencies
+haveSameAmount([dineroUSD, dineroEUR]);
+
+// @ts-expect-error - Different currencies
+normalizeScale([dineroUSD, dineroEUR]);
+
+/**
+ * Unary operations preserve currency
+ */
+
+const allocated = allocate(dineroUSD, [50, 50]);
+// Each allocation result should still be USD-typed
+add(allocated[0], dineroUSD);
+// @ts-expect-error - Allocated USD + EUR
+add(allocated[0], dineroEUR);
+
+const multiplied = multiply(dineroUSD, 2);
+add(multiplied, dineroUSD);
+// @ts-expect-error - Multiplied USD + EUR
+add(multiplied, dineroEUR);
+
+const trimmed = trimScale(dineroUSD);
+add(trimmed, dineroUSD);
+// @ts-expect-error - Trimmed USD + EUR
+add(trimmed, dineroEUR);
+
+const transformed = transformScale(dineroUSD, 4);
+add(transformed, dineroUSD);
+// @ts-expect-error - Transformed USD + EUR
+add(transformed, dineroEUR);
+
+/**
+ * `convert` changes currency type
+ */
+
+const converted = convert(dineroUSD, EUR, { EUR: { amount: 89, scale: 2 } });
+// Converted object should be EUR-typed
+add(converted, dineroEUR);
+// @ts-expect-error - Converted EUR + USD
+add(converted, dineroUSD);
+
+/**
+ * `toSnapshot` preserves currency type
+ */
+
+const snapshot = toSnapshot(dineroUSD);
+// Snapshot currency should be compatible with USD
+const _usdCode: 'USD' = snapshot.currency.code;
+
+/**
+ * `toDecimal` transformer receives typed currency
+ */
+
+toDecimal(dineroUSD, ({ currency }) => {
+  const _code: 'USD' = currency.code;
+
+  return _code;
+});
+
+/**
+ * `toUnits` transformer receives typed currency
+ */
+
+toUnits(dineroUSD, ({ currency }) => {
+  const _code: 'USD' = currency.code;
+
+  return _code;
+});
+
+/**
+ * `haveSameCurrency` accepts different currencies (intentional — it's a runtime check)
+ */
+
+haveSameCurrency([dineroUSD, dineroEUR]);
+
+/**
+ * Untyped currencies (plain string) still work (backward compatibility)
+ */
+
+const untypedCurrency = { code: 'XYZ', base: 10, exponent: 2 };
+const dineroUntyped1 = dinero({ amount: 100, currency: untypedCurrency });
+const dineroUntyped2 = dinero({ amount: 200, currency: untypedCurrency });
+
+// Two untyped Dinero objects can be added (both are string)
+add(dineroUntyped1, dineroUntyped2);

--- a/packages/dinero.js/src/api/__tests__/add.test.ts
+++ b/packages/dinero.js/src/api/__tests__/add.test.ts
@@ -56,6 +56,7 @@ describe('add', () => {
         const d2 = dinero({ amount: 100, currency: EUR });
 
         expect(() => {
+          // @ts-expect-error different currencies
           add(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -104,6 +105,7 @@ describe('add', () => {
         const d2 = dinero({ amount: 8, currency: MGA });
 
         expect(() => {
+          // @ts-expect-error different currencies
           add(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -190,6 +192,7 @@ describe('add', () => {
         const d2 = dinero({ amount: 100n, currency: bigintEUR });
 
         expect(() => {
+          // @ts-expect-error different currencies
           add(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -238,6 +241,7 @@ describe('add', () => {
         const d2 = dinero({ amount: 8n, currency: bigintMGA });
 
         expect(() => {
+          // @ts-expect-error different currencies
           add(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -328,6 +332,7 @@ describe('add', () => {
         const d2 = dinero({ amount: new Big(100), currency: bigjsEUR });
 
         expect(() => {
+          // @ts-expect-error different currencies
           add(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -380,6 +385,7 @@ describe('add', () => {
         const d2 = dinero({ amount: new Big(8), currency: bigjsMGA });
 
         expect(() => {
+          // @ts-expect-error different currencies
           add(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`

--- a/packages/dinero.js/src/api/__tests__/compare.test.ts
+++ b/packages/dinero.js/src/api/__tests__/compare.test.ts
@@ -44,6 +44,7 @@ describe('compare', () => {
         const d2 = dinero({ amount: 500, currency: EUR });
 
         expect(() => {
+          // @ts-expect-error different currencies
           compare(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -80,6 +81,7 @@ describe('compare', () => {
         const d2 = dinero({ amount: 5, currency: MGA });
 
         expect(() => {
+          // @ts-expect-error different currencies
           compare(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -135,6 +137,7 @@ describe('compare', () => {
         const d2 = dinero({ amount: 500n, currency: bigintEUR });
 
         expect(() => {
+          // @ts-expect-error different currencies
           compare(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -171,6 +174,7 @@ describe('compare', () => {
         const d2 = dinero({ amount: 5n, currency: bigintMGA });
 
         expect(() => {
+          // @ts-expect-error different currencies
           compare(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -230,6 +234,7 @@ describe('compare', () => {
         const d2 = dinero({ amount: new Big(500), currency: bigjsEUR });
 
         expect(() => {
+          // @ts-expect-error different currencies
           compare(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -270,6 +275,7 @@ describe('compare', () => {
         const d2 = dinero({ amount: new Big(5), currency: bigjsMGA });
 
         expect(() => {
+          // @ts-expect-error different currencies
           compare(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`

--- a/packages/dinero.js/src/api/__tests__/equal.test.ts
+++ b/packages/dinero.js/src/api/__tests__/equal.test.ts
@@ -31,12 +31,14 @@ describe('equal', () => {
         const d1 = dinero({ amount: 500, currency: USD });
         const d2 = dinero({ amount: 500, currency: EUR });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns false when amounts and currencies are not equal', () => {
         const d1 = dinero({ amount: 500, currency: USD });
         const d2 = dinero({ amount: 800, currency: EUR });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns true when amounts are equal after normalization', () => {
@@ -69,12 +71,14 @@ describe('equal', () => {
         const d1 = dinero({ amount: 500, currency: USD });
         const d2 = dinero({ amount: 500, currency: MGA });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns false when amounts and currencies are not equal', () => {
         const d1 = dinero({ amount: 500, currency: USD });
         const d2 = dinero({ amount: 8, currency: MGA });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns true when amounts are equal after normalization', () => {
@@ -114,12 +118,14 @@ describe('equal', () => {
         const d1 = dinero({ amount: 500n, currency: bigintUSD });
         const d2 = dinero({ amount: 500n, currency: bigintEUR });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns false when amounts and currencies are not equal', () => {
         const d1 = dinero({ amount: 500n, currency: bigintUSD });
         const d2 = dinero({ amount: 800n, currency: bigintEUR });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns true when amounts are equal after normalization', () => {
@@ -152,12 +158,14 @@ describe('equal', () => {
         const d1 = dinero({ amount: 500n, currency: bigintUSD });
         const d2 = dinero({ amount: 500n, currency: bigintMGA });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns false when amounts and currencies are not equal', () => {
         const d1 = dinero({ amount: 500n, currency: bigintUSD });
         const d2 = dinero({ amount: 8n, currency: bigintMGA });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns true when amounts are equal after normalization', () => {
@@ -197,12 +205,14 @@ describe('equal', () => {
         const d1 = dinero({ amount: new Big(500), currency: bigjsUSD });
         const d2 = dinero({ amount: new Big(500), currency: bigjsEUR });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns false when amounts and currencies are not equal', () => {
         const d1 = dinero({ amount: new Big(500), currency: bigjsUSD });
         const d2 = dinero({ amount: new Big(800), currency: bigjsEUR });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns true when amounts are equal after normalization', () => {
@@ -243,12 +253,14 @@ describe('equal', () => {
         const d1 = dinero({ amount: new Big(500), currency: bigjsUSD });
         const d2 = dinero({ amount: new Big(500), currency: bigjsMGA });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns false when amounts and currencies are not equal', () => {
         const d1 = dinero({ amount: new Big(500), currency: bigjsUSD });
         const d2 = dinero({ amount: new Big(8), currency: bigjsMGA });
 
+        // @ts-expect-error different currencies
         expect(equal(d1, d2)).toBe(false);
       });
       it('returns true when amounts are equal after normalization', () => {

--- a/packages/dinero.js/src/api/__tests__/greaterThan.test.ts
+++ b/packages/dinero.js/src/api/__tests__/greaterThan.test.ts
@@ -44,6 +44,7 @@ describe('greaterThan', () => {
         const d2 = dinero({ amount: 500, currency: EUR });
 
         expect(() => {
+          // @ts-expect-error different currencies
           greaterThan(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -80,6 +81,7 @@ describe('greaterThan', () => {
         const d2 = dinero({ amount: 500, currency: MGA });
 
         expect(() => {
+          // @ts-expect-error different currencies
           greaterThan(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -123,6 +125,7 @@ describe('greaterThan', () => {
         const d2 = dinero({ amount: 500n, currency: bigintEUR });
 
         expect(() => {
+          // @ts-expect-error different currencies
           greaterThan(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -159,6 +162,7 @@ describe('greaterThan', () => {
         const d2 = dinero({ amount: 500n, currency: bigintMGA });
 
         expect(() => {
+          // @ts-expect-error different currencies
           greaterThan(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -206,6 +210,7 @@ describe('greaterThan', () => {
         const d2 = dinero({ amount: new Big(500), currency: bigjsEUR });
 
         expect(() => {
+          // @ts-expect-error different currencies
           greaterThan(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -246,6 +251,7 @@ describe('greaterThan', () => {
         const d2 = dinero({ amount: new Big(500), currency: bigjsMGA });
 
         expect(() => {
+          // @ts-expect-error different currencies
           greaterThan(d1, d2);
         }).toThrowErrorMatchingInlineSnapshot(
           `[Error: [Dinero.js] Objects must have the same currency.]`

--- a/packages/dinero.js/src/api/__tests__/greaterThanOrEqual.test.ts
+++ b/packages/dinero.js/src/api/__tests__/greaterThanOrEqual.test.ts
@@ -43,6 +43,7 @@ describe('greaterThanOrEqual', () => {
       const d2 = dinero({ amount: 500, currency: EUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         greaterThanOrEqual(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -83,6 +84,7 @@ describe('greaterThanOrEqual', () => {
       const d2 = dinero({ amount: 500n, currency: bigintEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         greaterThanOrEqual(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -127,6 +129,7 @@ describe('greaterThanOrEqual', () => {
       const d2 = dinero({ amount: new Big(500), currency: bigjsEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         greaterThanOrEqual(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`

--- a/packages/dinero.js/src/api/__tests__/lessThan.test.ts
+++ b/packages/dinero.js/src/api/__tests__/lessThan.test.ts
@@ -43,6 +43,7 @@ describe('lessThan', () => {
       const d2 = dinero({ amount: 500, currency: EUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         lessThan(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -83,6 +84,7 @@ describe('lessThan', () => {
       const d2 = dinero({ amount: 500n, currency: bigintEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         lessThan(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -127,6 +129,7 @@ describe('lessThan', () => {
       const d2 = dinero({ amount: new Big(500), currency: bigjsEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         lessThan(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`

--- a/packages/dinero.js/src/api/__tests__/lessThanOrEqual.test.ts
+++ b/packages/dinero.js/src/api/__tests__/lessThanOrEqual.test.ts
@@ -43,6 +43,7 @@ describe('lessThanOrEqual', () => {
       const d2 = dinero({ amount: 800, currency: EUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         lessThanOrEqual(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -83,6 +84,7 @@ describe('lessThanOrEqual', () => {
       const d2 = dinero({ amount: 800n, currency: bigintEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         lessThanOrEqual(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -127,6 +129,7 @@ describe('lessThanOrEqual', () => {
       const d2 = dinero({ amount: new Big(800), currency: bigjsEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         lessThanOrEqual(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`

--- a/packages/dinero.js/src/api/__tests__/maximum.test.ts
+++ b/packages/dinero.js/src/api/__tests__/maximum.test.ts
@@ -43,6 +43,7 @@ describe('maximum', () => {
       const d2 = dinero({ amount: 50, currency: EUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         maximum([d1, d2]);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -83,6 +84,7 @@ describe('maximum', () => {
       const d2 = dinero({ amount: 50n, currency: bigintEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         maximum([d1, d2]);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -127,6 +129,7 @@ describe('maximum', () => {
       const d2 = dinero({ amount: new Big(50), currency: bigjsEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         maximum([d1, d2]);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`

--- a/packages/dinero.js/src/api/__tests__/minimum.test.ts
+++ b/packages/dinero.js/src/api/__tests__/minimum.test.ts
@@ -43,6 +43,7 @@ describe('minimum', () => {
       const d2 = dinero({ amount: 50, currency: EUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         minimum([d1, d2]);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -83,6 +84,7 @@ describe('minimum', () => {
       const d2 = dinero({ amount: 50n, currency: bigintEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         minimum([d1, d2]);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -127,6 +129,7 @@ describe('minimum', () => {
       const d2 = dinero({ amount: new Big(50), currency: bigjsEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         minimum([d1, d2]);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`

--- a/packages/dinero.js/src/api/__tests__/subtract.test.ts
+++ b/packages/dinero.js/src/api/__tests__/subtract.test.ts
@@ -55,6 +55,7 @@ describe('subtract', () => {
       const d2 = dinero({ amount: 100, currency: EUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         subtract(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -107,6 +108,7 @@ describe('subtract', () => {
       const d2 = dinero({ amount: 100n, currency: bigintEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         subtract(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`
@@ -163,6 +165,7 @@ describe('subtract', () => {
       const d2 = dinero({ amount: new Big(100), currency: bigjsEUR });
 
       expect(() => {
+        // @ts-expect-error different currencies
         subtract(d1, d2);
       }).toThrowErrorMatchingInlineSnapshot(
         `[Error: [Dinero.js] Objects must have the same currency.]`

--- a/packages/dinero.js/src/api/add.ts
+++ b/packages/dinero.js/src/api/add.ts
@@ -11,7 +11,9 @@ import type { AddParams } from '../core';
  *
  * @public
  */
-export function add<TAmount>(...[augend, addend]: AddParams<TAmount>) {
+export function add<TAmount, TCurrency extends string>(
+  ...[augend, addend]: AddParams<TAmount, TCurrency>
+) {
   const { calculator } = augend;
   const addFn = safeAdd(calculator);
 

--- a/packages/dinero.js/src/api/allocate.ts
+++ b/packages/dinero.js/src/api/allocate.ts
@@ -11,8 +11,8 @@ import type { AllocateParams } from '../core';
  *
  * @public
  */
-export function allocate<TAmount>(
-  ...[dineroObject, ratios]: AllocateParams<TAmount>
+export function allocate<TAmount, TCurrency extends string>(
+  ...[dineroObject, ratios]: AllocateParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const allocateFn = safeAllocate(calculator);

--- a/packages/dinero.js/src/api/compare.ts
+++ b/packages/dinero.js/src/api/compare.ts
@@ -11,8 +11,8 @@ import type { CompareParams } from '../core';
  *
  * @public
  */
-export function compare<TAmount>(
-  ...[dineroObject, comparator]: CompareParams<TAmount>
+export function compare<TAmount, TCurrency extends string>(
+  ...[dineroObject, comparator]: CompareParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const compareFn = safeCompare(calculator);

--- a/packages/dinero.js/src/api/convert.ts
+++ b/packages/dinero.js/src/api/convert.ts
@@ -12,8 +12,16 @@ import type { ConvertParams } from '../core';
  *
  * @public
  */
-export function convert<TAmount>(
-  ...[dineroObject, newCurrency, rates]: ConvertParams<TAmount>
+export function convert<
+  TAmount,
+  TCurrency extends string,
+  TNewCurrency extends string,
+>(
+  ...[dineroObject, newCurrency, rates]: ConvertParams<
+    TAmount,
+    TCurrency,
+    TNewCurrency
+  >
 ) {
   const { calculator } = dineroObject;
   const converter = coreConvert(calculator);

--- a/packages/dinero.js/src/api/equal.ts
+++ b/packages/dinero.js/src/api/equal.ts
@@ -11,8 +11,8 @@ import type { EqualParams } from '../core';
  *
  * @public
  */
-export function equal<TAmount>(
-  ...[dineroObject, comparator]: EqualParams<TAmount>
+export function equal<TAmount, TCurrency extends string>(
+  ...[dineroObject, comparator]: EqualParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const equalFn = coreEqual(calculator);

--- a/packages/dinero.js/src/api/greaterThan.ts
+++ b/packages/dinero.js/src/api/greaterThan.ts
@@ -11,8 +11,8 @@ import type { GreaterThanParams } from '../core';
  *
  * @public
  */
-export function greaterThan<TAmount>(
-  ...[dineroObject, comparator]: GreaterThanParams<TAmount>
+export function greaterThan<TAmount, TCurrency extends string>(
+  ...[dineroObject, comparator]: GreaterThanParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const greaterThanFn = safeGreaterThan(calculator);

--- a/packages/dinero.js/src/api/greaterThanOrEqual.ts
+++ b/packages/dinero.js/src/api/greaterThanOrEqual.ts
@@ -11,8 +11,8 @@ import type { GreaterThanOrEqualParams } from '../core';
  *
  * @public
  */
-export function greaterThanOrEqual<TAmount>(
-  ...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount>
+export function greaterThanOrEqual<TAmount, TCurrency extends string>(
+  ...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const greaterThanOrEqualFn = safeGreaterThanOrEqual(calculator);

--- a/packages/dinero.js/src/api/haveSameAmount.ts
+++ b/packages/dinero.js/src/api/haveSameAmount.ts
@@ -10,8 +10,8 @@ import type { HaveSameAmountParams } from '../core';
  *
  * @public
  */
-export function haveSameAmount<TAmount>(
-  ...[dineroObjects]: HaveSameAmountParams<TAmount>
+export function haveSameAmount<TAmount, TCurrency extends string>(
+  ...[dineroObjects]: HaveSameAmountParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObjects[0];
   const haveSameAmountFn = coreHaveSameAmount(calculator);

--- a/packages/dinero.js/src/api/lessThan.ts
+++ b/packages/dinero.js/src/api/lessThan.ts
@@ -11,8 +11,8 @@ import type { LessThanParams } from '../core';
  *
  * @public
  */
-export function lessThan<TAmount>(
-  ...[dineroObject, comparator]: LessThanParams<TAmount>
+export function lessThan<TAmount, TCurrency extends string>(
+  ...[dineroObject, comparator]: LessThanParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const lessThanFn = safeLessThan(calculator);

--- a/packages/dinero.js/src/api/lessThanOrEqual.ts
+++ b/packages/dinero.js/src/api/lessThanOrEqual.ts
@@ -11,8 +11,8 @@ import type { LessThanOrEqualParams } from '../core';
  *
  * @public
  */
-export function lessThanOrEqual<TAmount>(
-  ...[dineroObject, comparator]: LessThanOrEqualParams<TAmount>
+export function lessThanOrEqual<TAmount, TCurrency extends string>(
+  ...[dineroObject, comparator]: LessThanOrEqualParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const lessThanOrEqualFn = safeLessThanOrEqual(calculator);

--- a/packages/dinero.js/src/api/maximum.ts
+++ b/packages/dinero.js/src/api/maximum.ts
@@ -10,7 +10,9 @@ import type { MaximumParams } from '../core';
  *
  * @public
  */
-export function maximum<TAmount>(...[dineroObjects]: MaximumParams<TAmount>) {
+export function maximum<TAmount, TCurrency extends string>(
+  ...[dineroObjects]: MaximumParams<TAmount, TCurrency>
+) {
   const { calculator } = dineroObjects[0];
   const maximumFn = safeMaximum(calculator);
 

--- a/packages/dinero.js/src/api/minimum.ts
+++ b/packages/dinero.js/src/api/minimum.ts
@@ -10,7 +10,9 @@ import type { MinimumParams } from '../core';
  *
  * @public
  */
-export function minimum<TAmount>(...[dineroObjects]: MinimumParams<TAmount>) {
+export function minimum<TAmount, TCurrency extends string>(
+  ...[dineroObjects]: MinimumParams<TAmount, TCurrency>
+) {
   const { calculator } = dineroObjects[0];
   const minimumFn = safeMinimum(calculator);
 

--- a/packages/dinero.js/src/api/multiply.ts
+++ b/packages/dinero.js/src/api/multiply.ts
@@ -11,8 +11,8 @@ import type { MultiplyParams } from '../core';
  *
  * @public
  */
-export function multiply<TAmount>(
-  ...[multiplicand, multiplier]: MultiplyParams<TAmount>
+export function multiply<TAmount, TCurrency extends string>(
+  ...[multiplicand, multiplier]: MultiplyParams<TAmount, TCurrency>
 ) {
   const { calculator } = multiplicand;
   const multiplyFn = coreMultiply(calculator);

--- a/packages/dinero.js/src/api/normalizeScale.ts
+++ b/packages/dinero.js/src/api/normalizeScale.ts
@@ -10,8 +10,8 @@ import type { NormalizeScaleParams } from '../core';
  *
  * @public
  */
-export function normalizeScale<TAmount>(
-  ...[dineroObjects]: NormalizeScaleParams<TAmount>
+export function normalizeScale<TAmount, TCurrency extends string>(
+  ...[dineroObjects]: NormalizeScaleParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObjects[0];
   const normalizeScaleFn = coreNormalizeScale(calculator);

--- a/packages/dinero.js/src/api/subtract.ts
+++ b/packages/dinero.js/src/api/subtract.ts
@@ -11,8 +11,8 @@ import type { SubtractParams } from '../core';
  *
  * @public
  */
-export function subtract<TAmount>(
-  ...[minuend, subtrahend]: SubtractParams<TAmount>
+export function subtract<TAmount, TCurrency extends string>(
+  ...[minuend, subtrahend]: SubtractParams<TAmount, TCurrency>
 ) {
   const { calculator } = minuend;
   const subtractFn = safeSubtract(calculator);

--- a/packages/dinero.js/src/api/toDecimal.ts
+++ b/packages/dinero.js/src/api/toDecimal.ts
@@ -1,11 +1,13 @@
 import { toDecimal as coreToDecimal } from '../core';
 import type { ToDecimalParams, Dinero, DineroTransformer } from '../core';
 
-export function toDecimal<TAmount>(dineroObject: Dinero<TAmount>): string;
+export function toDecimal<TAmount, TCurrency extends string>(
+  dineroObject: Dinero<TAmount, TCurrency>
+): string;
 
-export function toDecimal<TAmount, TOutput>(
-  dineroObject: Dinero<TAmount>,
-  transformer: DineroTransformer<TAmount, TOutput, string>
+export function toDecimal<TAmount, TOutput, TCurrency extends string>(
+  dineroObject: Dinero<TAmount, TCurrency>,
+  transformer: DineroTransformer<TAmount, TOutput, string, TCurrency>
 ): TOutput;
 
 /**
@@ -18,8 +20,8 @@ export function toDecimal<TAmount, TOutput>(
  *
  * @public
  */
-export function toDecimal<TAmount, TOutput>(
-  ...[dineroObject, transformer]: ToDecimalParams<TAmount, TOutput>
+export function toDecimal<TAmount, TOutput, TCurrency extends string>(
+  ...[dineroObject, transformer]: ToDecimalParams<TAmount, TOutput, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const toDecimalFn = coreToDecimal<TAmount, TOutput>(calculator);

--- a/packages/dinero.js/src/api/toUnits.ts
+++ b/packages/dinero.js/src/api/toUnits.ts
@@ -1,13 +1,18 @@
 import { toUnits as coreToUnits } from '../core';
 import type { ToUnitsParams, Dinero, DineroTransformer } from '../core';
 
-export function toUnits<TAmount>(
-  dineroObject: Dinero<TAmount>
+export function toUnits<TAmount, TCurrency extends string>(
+  dineroObject: Dinero<TAmount, TCurrency>
 ): readonly TAmount[];
 
-export function toUnits<TAmount, TOutput>(
-  dineroObject: Dinero<TAmount>,
-  transformer: DineroTransformer<TAmount, TOutput, readonly TAmount[]>
+export function toUnits<TAmount, TOutput, TCurrency extends string>(
+  dineroObject: Dinero<TAmount, TCurrency>,
+  transformer: DineroTransformer<
+    TAmount,
+    TOutput,
+    readonly TAmount[],
+    TCurrency
+  >
 ): TOutput;
 
 /**
@@ -20,8 +25,8 @@ export function toUnits<TAmount, TOutput>(
  *
  * @public
  */
-export function toUnits<TAmount, TOutput>(
-  ...[dineroObject, transformer]: ToUnitsParams<TAmount, TOutput>
+export function toUnits<TAmount, TOutput, TCurrency extends string>(
+  ...[dineroObject, transformer]: ToUnitsParams<TAmount, TOutput, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const toUnitsFn = coreToUnits<TAmount, TOutput>(calculator);

--- a/packages/dinero.js/src/api/transformScale.ts
+++ b/packages/dinero.js/src/api/transformScale.ts
@@ -12,8 +12,8 @@ import type { TransformScaleParams } from '../core';
  *
  * @public
  */
-export function transformScale<TAmount>(
-  ...[dineroObject, newScale, divide]: TransformScaleParams<TAmount>
+export function transformScale<TAmount, TCurrency extends string>(
+  ...[dineroObject, newScale, divide]: TransformScaleParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const transformScaleFn = coreTransformScale(calculator);

--- a/packages/dinero.js/src/api/trimScale.ts
+++ b/packages/dinero.js/src/api/trimScale.ts
@@ -10,8 +10,8 @@ import type { TrimScaleParams } from '../core';
  *
  * @public
  */
-export function trimScale<TAmount>(
-  ...[dineroObject]: TrimScaleParams<TAmount>
+export function trimScale<TAmount, TCurrency extends string>(
+  ...[dineroObject]: TrimScaleParams<TAmount, TCurrency>
 ) {
   const { calculator } = dineroObject;
   const trimScaleFn = coreTrimScale(calculator);

--- a/packages/dinero.js/src/core/api/add.ts
+++ b/packages/dinero.js/src/core/api/add.ts
@@ -5,13 +5,15 @@ import type { DineroCalculator, Dinero } from '../types';
 import { haveSameCurrency } from './haveSameCurrency';
 import { normalizeScale } from './normalizeScale';
 
-export type AddParams<TAmount> = readonly [
-  augend: Dinero<TAmount>,
-  addend: Dinero<TAmount>,
+export type AddParams<TAmount, TCurrency extends string = string> = readonly [
+  augend: Dinero<TAmount, TCurrency>,
+  addend: Dinero<TAmount, NoInfer<TCurrency>>,
 ];
 
 function unsafeAdd<TAmount>(calculator: DineroCalculator<TAmount>) {
-  return function add(...[augend, addend]: AddParams<TAmount>) {
+  return function add<TCurrency extends string>(
+    ...[augend, addend]: AddParams<TAmount, TCurrency>
+  ) {
     const { amount: augendAmount, currency, scale } = augend.toJSON();
     const { amount: addendAmount } = addend.toJSON();
 
@@ -29,7 +31,9 @@ export function safeAdd<TAmount>(calculator: DineroCalculator<TAmount>) {
   const normalizeFn = normalizeScale(calculator);
   const addFn = unsafeAdd(calculator);
 
-  return function add(...[augend, addend]: AddParams<TAmount>) {
+  return function add<TCurrency extends string>(
+    ...[augend, addend]: AddParams<TAmount, TCurrency>
+  ) {
     const condition = haveSameCurrency([augend, addend]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/dinero.js/src/core/api/allocate.ts
+++ b/packages/dinero.js/src/core/api/allocate.ts
@@ -12,14 +12,17 @@ import {
 
 import { transformScale } from './transformScale';
 
-type UnsafeAllocateParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
+type UnsafeAllocateParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
   ratios: ReadonlyArray<DineroScaledAmount<TAmount>>,
 ];
 
 function unsafeAllocate<TAmount>(calculator: DineroCalculator<TAmount>) {
-  return function allocate(
-    ...[dineroObject, ratios]: UnsafeAllocateParams<TAmount>
+  return function allocate<TCurrency extends string>(
+    ...[dineroObject, ratios]: UnsafeAllocateParams<TAmount, TCurrency>
   ) {
     const { amount, currency, scale } = dineroObject.toJSON();
     const distributeFn = distribute(calculator);
@@ -38,8 +41,11 @@ function unsafeAllocate<TAmount>(calculator: DineroCalculator<TAmount>) {
   };
 }
 
-export type AllocateParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
+export type AllocateParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
   ratios: ReadonlyArray<DineroScaledAmount<TAmount> | TAmount>,
 ];
 
@@ -53,7 +59,9 @@ export function safeAllocate<TAmount>(calculator: DineroCalculator<TAmount>) {
   const zero = calculator.zero();
   const ten = new Array(10).fill(null).reduce(calculator.increment, zero);
 
-  return function allocate(...[dineroObject, ratios]: AllocateParams<TAmount>) {
+  return function allocate<TCurrency extends string>(
+    ...[dineroObject, ratios]: AllocateParams<TAmount, TCurrency>
+  ) {
     const hasRatios = ratios.length > 0;
     const scaledRatios = ratios.map((ratio) => getAmountAndScale(ratio, zero));
     const highestRatioScale = hasRatios

--- a/packages/dinero.js/src/core/api/compare.ts
+++ b/packages/dinero.js/src/core/api/compare.ts
@@ -6,16 +6,19 @@ import { compare as cmp } from '../utils';
 import { haveSameCurrency } from './haveSameCurrency';
 import { normalizeScale } from './normalizeScale';
 
-export type CompareParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
-  comparator: Dinero<TAmount>,
+export type CompareParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
+  comparator: Dinero<TAmount, NoInfer<TCurrency>>,
 ];
 
 function unsafeCompare<TAmount>(calculator: DineroCalculator<TAmount>) {
   const compareFn = cmp(calculator);
 
-  return function compare(
-    ...[dineroObject, comparator]: CompareParams<TAmount>
+  return function compare<TCurrency extends string>(
+    ...[dineroObject, comparator]: CompareParams<TAmount, TCurrency>
   ) {
     const dineroObjects = [dineroObject, comparator];
 
@@ -33,8 +36,8 @@ export function safeCompare<TAmount>(calculator: DineroCalculator<TAmount>) {
   const normalizeFn = normalizeScale(calculator);
   const compareFn = unsafeCompare(calculator);
 
-  return function compare(
-    ...[dineroObject, comparator]: CompareParams<TAmount>
+  return function compare<TCurrency extends string>(
+    ...[dineroObject, comparator]: CompareParams<TAmount, TCurrency>
   ) {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);

--- a/packages/dinero.js/src/core/api/convert.ts
+++ b/packages/dinero.js/src/core/api/convert.ts
@@ -5,9 +5,13 @@ import { getAmountAndScale, maximum } from '../utils';
 
 import { transformScale } from './transformScale';
 
-export type ConvertParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
-  newCurrency: DineroCurrency<TAmount>,
+export type ConvertParams<
+  TAmount,
+  TCurrency extends string = string,
+  TNewCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
+  newCurrency: DineroCurrency<TAmount, TNewCurrency>,
   rates: DineroRates<TAmount>,
 ];
 
@@ -16,8 +20,15 @@ export function convert<TAmount>(calculator: DineroCalculator<TAmount>) {
   const maximumFn = maximum(calculator);
   const zero = calculator.zero();
 
-  return function convertFn(
-    ...[dineroObject, newCurrency, rates]: ConvertParams<TAmount>
+  return function convertFn<
+    TCurrency extends string,
+    TNewCurrency extends string,
+  >(
+    ...[dineroObject, newCurrency, rates]: ConvertParams<
+      TAmount,
+      TCurrency,
+      TNewCurrency
+    >
   ) {
     const rate = rates[newCurrency.code];
     const { amount, scale } = dineroObject.toJSON();

--- a/packages/dinero.js/src/core/api/equal.ts
+++ b/packages/dinero.js/src/core/api/equal.ts
@@ -3,13 +3,15 @@ import type { DineroCalculator, Dinero } from '../types';
 import { haveSameAmount } from './haveSameAmount';
 import { haveSameCurrency } from './haveSameCurrency';
 
-export type EqualParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
-  comparator: Dinero<TAmount>,
+export type EqualParams<TAmount, TCurrency extends string = string> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
+  comparator: Dinero<TAmount, NoInfer<TCurrency>>,
 ];
 
 export function equal<TAmount>(calculator: DineroCalculator<TAmount>) {
-  return function _equal(...[dineroObject, comparator]: EqualParams<TAmount>) {
+  return function _equal<TCurrency extends string>(
+    ...[dineroObject, comparator]: EqualParams<TAmount, TCurrency>
+  ) {
     return (
       haveSameAmount(calculator)([dineroObject, comparator]) &&
       haveSameCurrency([dineroObject, comparator])

--- a/packages/dinero.js/src/core/api/greaterThan.ts
+++ b/packages/dinero.js/src/core/api/greaterThan.ts
@@ -6,16 +6,19 @@ import { greaterThan as gt } from '../utils';
 import { haveSameCurrency } from './haveSameCurrency';
 import { normalizeScale } from './normalizeScale';
 
-export type GreaterThanParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
-  comparator: Dinero<TAmount>,
+export type GreaterThanParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
+  comparator: Dinero<TAmount, NoInfer<TCurrency>>,
 ];
 
 function unsafeGreaterThan<TAmount>(calculator: DineroCalculator<TAmount>) {
   const greaterThanFn = gt(calculator);
 
-  return function greaterThan(
-    ...[dineroObject, comparator]: GreaterThanParams<TAmount>
+  return function greaterThan<TCurrency extends string>(
+    ...[dineroObject, comparator]: GreaterThanParams<TAmount, TCurrency>
   ) {
     const dineroObjects = [dineroObject, comparator];
 
@@ -35,8 +38,8 @@ export function safeGreaterThan<TAmount>(
   const normalizeFn = normalizeScale(calculator);
   const greaterThanFn = unsafeGreaterThan(calculator);
 
-  return function greaterThan(
-    ...[dineroObject, comparator]: GreaterThanParams<TAmount>
+  return function greaterThan<TCurrency extends string>(
+    ...[dineroObject, comparator]: GreaterThanParams<TAmount, TCurrency>
   ) {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);

--- a/packages/dinero.js/src/core/api/greaterThanOrEqual.ts
+++ b/packages/dinero.js/src/core/api/greaterThanOrEqual.ts
@@ -6,9 +6,12 @@ import { greaterThanOrEqual as gte } from '../utils';
 import { haveSameCurrency } from './haveSameCurrency';
 import { normalizeScale } from './normalizeScale';
 
-export type GreaterThanOrEqualParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
-  comparator: Dinero<TAmount>,
+export type GreaterThanOrEqualParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
+  comparator: Dinero<TAmount, NoInfer<TCurrency>>,
 ];
 
 function unsafeGreaterThanOrEqual<TAmount>(
@@ -16,8 +19,8 @@ function unsafeGreaterThanOrEqual<TAmount>(
 ) {
   const greaterThanOrEqualFn = gte(calculator);
 
-  return function greaterThanOrEqual(
-    ...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount>
+  return function greaterThanOrEqual<TCurrency extends string>(
+    ...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount, TCurrency>
   ) {
     const dineroObjects = [dineroObject, comparator];
 
@@ -37,8 +40,8 @@ export function safeGreaterThanOrEqual<TAmount>(
   const normalizeFn = normalizeScale(calculator);
   const greaterThanOrEqualFn = unsafeGreaterThanOrEqual(calculator);
 
-  return function greaterThanOrEqual(
-    ...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount>
+  return function greaterThanOrEqual<TCurrency extends string>(
+    ...[dineroObject, comparator]: GreaterThanOrEqualParams<TAmount, TCurrency>
   ) {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);

--- a/packages/dinero.js/src/core/api/haveSameAmount.ts
+++ b/packages/dinero.js/src/core/api/haveSameAmount.ts
@@ -3,16 +3,22 @@ import { equal } from '../utils';
 
 import { normalizeScale } from './normalizeScale';
 
-export type HaveSameAmountParams<TAmount> = readonly [
-  dineroObjects: ReadonlyArray<Dinero<TAmount>>,
+export type HaveSameAmountParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObjects: readonly [
+    Dinero<TAmount, TCurrency>,
+    ...Dinero<TAmount, NoInfer<TCurrency>>[],
+  ],
 ];
 
 export function haveSameAmount<TAmount>(calculator: DineroCalculator<TAmount>) {
   const normalizeFn = normalizeScale(calculator);
   const equalFn = equal(calculator);
 
-  return function _haveSameAmount(
-    ...[dineroObjects]: HaveSameAmountParams<TAmount>
+  return function _haveSameAmount<TCurrency extends string>(
+    ...[dineroObjects]: HaveSameAmountParams<TAmount, TCurrency>
   ) {
     const [firstDinero, ...otherDineros] = normalizeFn(dineroObjects);
     const { amount: comparatorAmount } = firstDinero.toJSON();

--- a/packages/dinero.js/src/core/api/lessThan.ts
+++ b/packages/dinero.js/src/core/api/lessThan.ts
@@ -6,16 +6,19 @@ import { lessThan as lt } from '../utils';
 import { haveSameCurrency } from './haveSameCurrency';
 import { normalizeScale } from './normalizeScale';
 
-export type LessThanParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
-  comparator: Dinero<TAmount>,
+export type LessThanParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
+  comparator: Dinero<TAmount, NoInfer<TCurrency>>,
 ];
 
 function unsafeLessThan<TAmount>(calculator: DineroCalculator<TAmount>) {
   const lessThanFn = lt(calculator);
 
-  return function lessThan(
-    ...[dineroObject, comparator]: LessThanParams<TAmount>
+  return function lessThan<TCurrency extends string>(
+    ...[dineroObject, comparator]: LessThanParams<TAmount, TCurrency>
   ) {
     const dineroObjects = [dineroObject, comparator];
 
@@ -33,8 +36,8 @@ export function safeLessThan<TAmount>(calculator: DineroCalculator<TAmount>) {
   const normalizeFn = normalizeScale(calculator);
   const lessThanFn = unsafeLessThan(calculator);
 
-  return function lessThan(
-    ...[dineroObject, comparator]: LessThanParams<TAmount>
+  return function lessThan<TCurrency extends string>(
+    ...[dineroObject, comparator]: LessThanParams<TAmount, TCurrency>
   ) {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);

--- a/packages/dinero.js/src/core/api/lessThanOrEqual.ts
+++ b/packages/dinero.js/src/core/api/lessThanOrEqual.ts
@@ -6,16 +6,19 @@ import { lessThanOrEqual as lte } from '../utils';
 import { haveSameCurrency } from './haveSameCurrency';
 import { normalizeScale } from './normalizeScale';
 
-export type LessThanOrEqualParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
-  comparator: Dinero<TAmount>,
+export type LessThanOrEqualParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
+  comparator: Dinero<TAmount, NoInfer<TCurrency>>,
 ];
 
 function unsafeLessThanOrEqual<TAmount>(calculator: DineroCalculator<TAmount>) {
   const lessThanOrEqualFn = lte(calculator);
 
-  return function lessThanOrEqual(
-    ...[dineroObject, comparator]: LessThanOrEqualParams<TAmount>
+  return function lessThanOrEqual<TCurrency extends string>(
+    ...[dineroObject, comparator]: LessThanOrEqualParams<TAmount, TCurrency>
   ) {
     const dineroObjects = [dineroObject, comparator];
 
@@ -35,8 +38,8 @@ export function safeLessThanOrEqual<TAmount>(
   const normalizeFn = normalizeScale(calculator);
   const lessThanOrEqualFn = unsafeLessThanOrEqual(calculator);
 
-  return function lessThanOrEqual(
-    ...[dineroObject, comparator]: LessThanOrEqualParams<TAmount>
+  return function lessThanOrEqual<TCurrency extends string>(
+    ...[dineroObject, comparator]: LessThanOrEqualParams<TAmount, TCurrency>
   ) {
     const condition = haveSameCurrency([dineroObject, comparator]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);

--- a/packages/dinero.js/src/core/api/minimum.ts
+++ b/packages/dinero.js/src/core/api/minimum.ts
@@ -6,14 +6,22 @@ import { minimum as min } from '../utils';
 import { haveSameCurrency } from './haveSameCurrency';
 import { normalizeScale } from './normalizeScale';
 
-export type MinimumParams<TAmount> = readonly [
-  dineroObjects: ReadonlyArray<Dinero<TAmount>>,
+export type MinimumParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObjects: readonly [
+    Dinero<TAmount, TCurrency>,
+    ...Dinero<TAmount, NoInfer<TCurrency>>[],
+  ],
 ];
 
 function unsafeMinimum<TAmount>(calculator: DineroCalculator<TAmount>) {
   const minFn = min(calculator);
 
-  return function minimum(...[dineroObjects]: MinimumParams<TAmount>) {
+  return function minimum<TCurrency extends string>(
+    dineroObjects: ReadonlyArray<Dinero<TAmount, TCurrency>>
+  ) {
     const [firstDinero] = dineroObjects;
     const { currency, scale } = firstDinero.toJSON();
 
@@ -37,11 +45,13 @@ export function safeMinimum<TAmount>(calculator: DineroCalculator<TAmount>) {
   const normalizeFn = normalizeScale(calculator);
   const minFn = unsafeMinimum(calculator);
 
-  return function maximum(...[dineroObjects]: MinimumParams<TAmount>) {
+  return function minimum<TCurrency extends string>(
+    ...[dineroObjects]: MinimumParams<TAmount, TCurrency>
+  ) {
     const condition = haveSameCurrency(dineroObjects);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 
-    const normalizedDineroObjects = normalizeFn(dineroObjects);
+    const normalizedDineroObjects = normalizeFn([...dineroObjects]);
 
     return minFn(normalizedDineroObjects);
   };

--- a/packages/dinero.js/src/core/api/multiply.ts
+++ b/packages/dinero.js/src/core/api/multiply.ts
@@ -3,8 +3,11 @@ import { getAmountAndScale } from '../utils';
 
 import { transformScale } from './transformScale';
 
-export type MultiplyParams<TAmount> = readonly [
-  multiplicand: Dinero<TAmount>,
+export type MultiplyParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  multiplicand: Dinero<TAmount, TCurrency>,
   multiplier: DineroScaledAmount<TAmount> | TAmount,
 ];
 
@@ -12,8 +15,8 @@ export function multiply<TAmount>(calculator: DineroCalculator<TAmount>) {
   const convertScaleFn = transformScale(calculator);
   const zero = calculator.zero();
 
-  return function multiplyFn(
-    ...[multiplicand, multiplier]: MultiplyParams<TAmount>
+  return function multiplyFn<TCurrency extends string>(
+    ...[multiplicand, multiplier]: MultiplyParams<TAmount, TCurrency>
   ) {
     const { amount, currency, scale } = multiplicand.toJSON();
     const { amount: multiplierAmount, scale: multiplierScale } =

--- a/packages/dinero.js/src/core/api/normalizeScale.ts
+++ b/packages/dinero.js/src/core/api/normalizeScale.ts
@@ -3,8 +3,14 @@ import { equal, maximum } from '../utils';
 
 import { transformScale } from './transformScale';
 
-export type NormalizeScaleParams<TAmount> = readonly [
-  dineroObjects: ReadonlyArray<Dinero<TAmount>>,
+export type NormalizeScaleParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObjects: readonly [
+    Dinero<TAmount, TCurrency>,
+    ...Dinero<TAmount, NoInfer<TCurrency>>[],
+  ],
 ];
 
 export function normalizeScale<TAmount>(calculator: DineroCalculator<TAmount>) {
@@ -12,8 +18,8 @@ export function normalizeScale<TAmount>(calculator: DineroCalculator<TAmount>) {
   const convertScaleFn = transformScale(calculator);
   const equalFn = equal(calculator);
 
-  return function _normalizeScale(
-    ...[dineroObjects]: NormalizeScaleParams<TAmount>
+  return function _normalizeScale<TCurrency extends string>(
+    ...[dineroObjects]: NormalizeScaleParams<TAmount, TCurrency>
   ) {
     const highestScale = dineroObjects.reduce((highest, current) => {
       const { scale } = current.toJSON();

--- a/packages/dinero.js/src/core/api/subtract.ts
+++ b/packages/dinero.js/src/core/api/subtract.ts
@@ -5,13 +5,18 @@ import type { DineroCalculator, Dinero } from '../types';
 import { haveSameCurrency } from './haveSameCurrency';
 import { normalizeScale } from './normalizeScale';
 
-export type SubtractParams<TAmount> = readonly [
-  minuend: Dinero<TAmount>,
-  subtrahend: Dinero<TAmount>,
+export type SubtractParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  minuend: Dinero<TAmount, TCurrency>,
+  subtrahend: Dinero<TAmount, NoInfer<TCurrency>>,
 ];
 
 function unsafeSubtract<TAmount>(calculator: DineroCalculator<TAmount>) {
-  return function subtract(...[minuend, subtrahend]: SubtractParams<TAmount>) {
+  return function subtract<TCurrency extends string>(
+    ...[minuend, subtrahend]: SubtractParams<TAmount, TCurrency>
+  ) {
     const { amount: minuendAmount, currency, scale } = minuend.toJSON();
     const { amount: subtrahendAmount } = subtrahend.toJSON();
 
@@ -29,7 +34,9 @@ export function safeSubtract<TAmount>(calculator: DineroCalculator<TAmount>) {
   const normalizeFn = normalizeScale(calculator);
   const subtractFn = unsafeSubtract(calculator);
 
-  return function subtract(...[minuend, subtrahend]: SubtractParams<TAmount>) {
+  return function subtract<TCurrency extends string>(
+    ...[minuend, subtrahend]: SubtractParams<TAmount, TCurrency>
+  ) {
     const condition = haveSameCurrency([minuend, subtrahend]);
     assert(condition, UNEQUAL_CURRENCIES_MESSAGE);
 

--- a/packages/dinero.js/src/core/api/toDecimal.ts
+++ b/packages/dinero.js/src/core/api/toDecimal.ts
@@ -10,9 +10,13 @@ import { absolute, computeBase, equal, isArray, lessThan } from '../utils';
 
 import { toUnits } from './toUnits';
 
-export type ToDecimalParams<TAmount, TOutput> = readonly [
-  dineroObject: Dinero<TAmount>,
-  transformer?: DineroTransformer<TAmount, TOutput, string>,
+export type ToDecimalParams<
+  TAmount,
+  TOutput,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
+  transformer?: DineroTransformer<TAmount, TOutput, string, TCurrency>,
 ];
 
 export function toDecimal<TAmount, TOutput>(
@@ -22,8 +26,8 @@ export function toDecimal<TAmount, TOutput>(
   const computeBaseFn = computeBase(calculator);
   const equalFn = equal(calculator);
 
-  return function toDecimalFn(
-    ...[dineroObject, transformer]: ToDecimalParams<TAmount, TOutput>
+  return function toDecimalFn<TCurrency extends string>(
+    ...[dineroObject, transformer]: ToDecimalParams<TAmount, TOutput, TCurrency>
   ) {
     const { currency, scale } = dineroObject.toJSON();
 

--- a/packages/dinero.js/src/core/api/toSnapshot.ts
+++ b/packages/dinero.js/src/core/api/toSnapshot.ts
@@ -1,5 +1,7 @@
 import type { Dinero } from '../types';
 
-export function toSnapshot<TAmount>(dineroObject: Dinero<TAmount>) {
+export function toSnapshot<TAmount, TCurrency extends string>(
+  dineroObject: Dinero<TAmount, TCurrency>
+) {
   return dineroObject.toJSON();
 }

--- a/packages/dinero.js/src/core/api/toUnits.ts
+++ b/packages/dinero.js/src/core/api/toUnits.ts
@@ -1,9 +1,18 @@
 import type { DineroCalculator, Dinero, DineroTransformer } from '../types';
 import { isArray, getDivisors } from '../utils';
 
-export type ToUnitsParams<TAmount, TOutput> = readonly [
-  dineroObject: Dinero<TAmount>,
-  transformer?: DineroTransformer<TAmount, TOutput, readonly TAmount[]>,
+export type ToUnitsParams<
+  TAmount,
+  TOutput,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
+  transformer?: DineroTransformer<
+    TAmount,
+    TOutput,
+    readonly TAmount[],
+    TCurrency
+  >,
 ];
 
 export function toUnits<TAmount, TOutput>(
@@ -11,8 +20,8 @@ export function toUnits<TAmount, TOutput>(
 ) {
   const getDivisorsFn = getDivisors(calculator);
 
-  return function toUnitsFn(
-    ...[dineroObject, transformer]: ToUnitsParams<TAmount, TOutput>
+  return function toUnitsFn<TCurrency extends string>(
+    ...[dineroObject, transformer]: ToUnitsParams<TAmount, TOutput, TCurrency>
   ) {
     const { amount, currency, scale } = dineroObject.toJSON();
     const { power, integerDivide, modulo } = calculator;

--- a/packages/dinero.js/src/core/api/transformScale.ts
+++ b/packages/dinero.js/src/core/api/transformScale.ts
@@ -2,8 +2,11 @@ import { down } from '../divide';
 import type { DineroCalculator, Dinero, DineroDivideOperation } from '../types';
 import { computeBase, greaterThan } from '../utils';
 
-export type TransformScaleParams<TAmount> = readonly [
-  dineroObject: Dinero<TAmount>,
+export type TransformScaleParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [
+  dineroObject: Dinero<TAmount, TCurrency>,
   newScale: TAmount,
   divide?: DineroDivideOperation,
 ];
@@ -12,8 +15,11 @@ export function transformScale<TAmount>(calculator: DineroCalculator<TAmount>) {
   const greaterThanFn = greaterThan(calculator);
   const computeBaseFn = computeBase(calculator);
 
-  return function transformScaleFn(
-    ...[dineroObject, newScale, divide = down]: TransformScaleParams<TAmount>
+  return function transformScaleFn<TCurrency extends string>(
+    ...[dineroObject, newScale, divide = down]: TransformScaleParams<
+      TAmount,
+      TCurrency
+    >
   ) {
     const { amount, currency, scale } = dineroObject.toJSON();
 

--- a/packages/dinero.js/src/core/api/trimScale.ts
+++ b/packages/dinero.js/src/core/api/trimScale.ts
@@ -3,7 +3,10 @@ import { computeBase, countTrailingZeros, equal, maximum } from '../utils';
 
 import { transformScale } from './transformScale';
 
-export type TrimScaleParams<TAmount> = readonly [dineroObject: Dinero<TAmount>];
+export type TrimScaleParams<
+  TAmount,
+  TCurrency extends string = string,
+> = readonly [dineroObject: Dinero<TAmount, TCurrency>];
 
 export function trimScale<TAmount>(calculator: DineroCalculator<TAmount>) {
   const countTrailingZerosFn = countTrailingZeros(calculator);
@@ -12,7 +15,9 @@ export function trimScale<TAmount>(calculator: DineroCalculator<TAmount>) {
   const transformScaleFn = transformScale(calculator);
   const computeBaseFn = computeBase(calculator);
 
-  return function trimScaleFn(...[dineroObject]: TrimScaleParams<TAmount>) {
+  return function trimScaleFn<TCurrency extends string>(
+    ...[dineroObject]: TrimScaleParams<TAmount, TCurrency>
+  ) {
     const { amount, currency, scale } = dineroObject.toJSON();
     const base = computeBaseFn(currency.base);
 

--- a/packages/dinero.js/src/core/helpers/createDinero.ts
+++ b/packages/dinero.js/src/core/helpers/createDinero.ts
@@ -1,3 +1,5 @@
+import type { DineroCurrency } from '../../currencies';
+
 import type {
   DineroCalculator,
   Dinero,
@@ -8,7 +10,7 @@ import type {
 export type CreateDineroOptions<TAmount> = {
   readonly calculator: DineroCalculator<TAmount>;
   readonly formatter?: DineroFormatter<TAmount>;
-  readonly onCreate?: (options: DineroOptions<TAmount>) => void;
+  readonly onCreate?: (options: DineroOptions<TAmount, string>) => void;
 };
 
 export function createDinero<TAmount>({
@@ -19,12 +21,15 @@ export function createDinero<TAmount>({
     toString: String,
   },
 }: CreateDineroOptions<TAmount>) {
-  return function dinero({
+  return function dinero<TCurrency extends string>({
     amount,
     currency: { code, base, exponent },
     scale = exponent,
-  }: DineroOptions<TAmount>): Dinero<TAmount> {
-    const currency = { code, base, exponent };
+  }: DineroOptions<TAmount, TCurrency>): Dinero<TAmount, TCurrency> {
+    const currency = { code, base, exponent } as DineroCurrency<
+      TAmount,
+      TCurrency
+    >;
 
     onCreate?.({ amount, currency, scale });
 

--- a/packages/dinero.js/src/core/types/Dinero.ts
+++ b/packages/dinero.js/src/core/types/Dinero.ts
@@ -5,9 +5,11 @@ import type {
   DineroSnapshot,
 } from '.';
 
-export type Dinero<TAmount> = {
+export type Dinero<TAmount, TCurrency extends string = string> = {
   readonly calculator: DineroCalculator<TAmount>;
   readonly formatter: DineroFormatter<TAmount>;
-  readonly create: (options: DineroOptions<TAmount>) => Dinero<TAmount>;
-  readonly toJSON: () => DineroSnapshot<TAmount>;
+  readonly create: <TC extends string = TCurrency>(
+    options: DineroOptions<TAmount, TC>
+  ) => Dinero<TAmount, TC>;
+  readonly toJSON: () => DineroSnapshot<TAmount, TCurrency>;
 };

--- a/packages/dinero.js/src/core/types/DineroFactory.ts
+++ b/packages/dinero.js/src/core/types/DineroFactory.ts
@@ -1,7 +1,7 @@
 import type { Dinero, DineroOptions } from '.';
 
-export type DineroFactory<TAmount> = ({
+export type DineroFactory<TAmount> = <TCurrency extends string>({
   amount,
   currency,
   scale,
-}: DineroOptions<TAmount>) => Dinero<TAmount>;
+}: DineroOptions<TAmount, TCurrency>) => Dinero<TAmount, TCurrency>;

--- a/packages/dinero.js/src/core/types/DineroOptions.ts
+++ b/packages/dinero.js/src/core/types/DineroOptions.ts
@@ -1,7 +1,7 @@
 import type { DineroCurrency } from '../../currencies';
 
-export type DineroOptions<TAmount> = {
+export type DineroOptions<TAmount, TCurrency extends string = string> = {
   readonly amount: TAmount;
-  readonly currency: DineroCurrency<TAmount>;
+  readonly currency: DineroCurrency<TAmount, TCurrency>;
   readonly scale?: TAmount;
 };

--- a/packages/dinero.js/src/core/types/DineroSnapshot.ts
+++ b/packages/dinero.js/src/core/types/DineroSnapshot.ts
@@ -1,7 +1,7 @@
 import type { DineroCurrency } from '../../currencies';
 
-export type DineroSnapshot<TAmount> = {
+export type DineroSnapshot<TAmount, TCurrency extends string = string> = {
   readonly amount: TAmount;
-  readonly currency: DineroCurrency<TAmount>;
+  readonly currency: DineroCurrency<TAmount, TCurrency>;
   readonly scale: TAmount;
 };

--- a/packages/dinero.js/src/core/types/DineroTransformer.ts
+++ b/packages/dinero.js/src/core/types/DineroTransformer.ts
@@ -1,10 +1,17 @@
 import type { DineroCurrency } from '../../currencies';
 
-export type TransformerOptions<TAmount, TValue> = {
+export type TransformerOptions<
+  TAmount,
+  TValue,
+  TCurrency extends string = string,
+> = {
   readonly value: TValue;
-  readonly currency: DineroCurrency<TAmount>;
+  readonly currency: DineroCurrency<TAmount, TCurrency>;
 };
 
-export type DineroTransformer<TAmount, TOutput, TValue> = (
-  options: TransformerOptions<TAmount, TValue>
-) => TOutput;
+export type DineroTransformer<
+  TAmount,
+  TOutput,
+  TValue,
+  TCurrency extends string = string,
+> = (options: TransformerOptions<TAmount, TValue, TCurrency>) => TOutput;

--- a/packages/dinero.js/src/currencies/iso4217.ts
+++ b/packages/dinero.js/src/currencies/iso4217.ts
@@ -12,1493 +12,1493 @@ import type { DineroCurrency } from './types';
 /**
  * United Arab Emirates dirham.
  */
-export const AED: DineroCurrency<number> = {
+export const AED = {
   code: 'AED',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'AED'>;
 
 /**
  * Afghan afghani.
  */
-export const AFN: DineroCurrency<number> = {
+export const AFN = {
   code: 'AFN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'AFN'>;
 
 /**
  * Albanian lek.
  */
-export const ALL: DineroCurrency<number> = {
+export const ALL = {
   code: 'ALL',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'ALL'>;
 
 /**
  * Armenian dram.
  */
-export const AMD: DineroCurrency<number> = {
+export const AMD = {
   code: 'AMD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'AMD'>;
 
 /**
  * Angolan kwanza.
  */
-export const AOA: DineroCurrency<number> = {
+export const AOA = {
   code: 'AOA',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'AOA'>;
 
 /**
  * Argentine peso.
  */
-export const ARS: DineroCurrency<number> = {
+export const ARS = {
   code: 'ARS',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'ARS'>;
 
 /**
  * Australian dollar.
  */
-export const AUD: DineroCurrency<number> = {
+export const AUD = {
   code: 'AUD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'AUD'>;
 
 /**
  * Aruban florin.
  */
-export const AWG: DineroCurrency<number> = {
+export const AWG = {
   code: 'AWG',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'AWG'>;
 
 /**
  * Azerbaijani manat.
  */
-export const AZN: DineroCurrency<number> = {
+export const AZN = {
   code: 'AZN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'AZN'>;
 
 /**
  * Bosnia and Herzegovina convertible mark.
  */
-export const BAM: DineroCurrency<number> = {
+export const BAM = {
   code: 'BAM',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BAM'>;
 
 /**
  * Barbados dollar.
  */
-export const BBD: DineroCurrency<number> = {
+export const BBD = {
   code: 'BBD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BBD'>;
 
 /**
  * Bangladeshi taka.
  */
-export const BDT: DineroCurrency<number> = {
+export const BDT = {
   code: 'BDT',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BDT'>;
 
 /**
  * Bulgarian lev.
  */
-export const BGN: DineroCurrency<number> = {
+export const BGN = {
   code: 'BGN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BGN'>;
 
 /**
  * Bahraini dinar.
  */
-export const BHD: DineroCurrency<number> = {
+export const BHD = {
   code: 'BHD',
   base: 10,
   exponent: 3,
-};
+} as const satisfies DineroCurrency<number, 'BHD'>;
 
 /**
  * Burundian franc.
  */
-export const BIF: DineroCurrency<number> = {
+export const BIF = {
   code: 'BIF',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'BIF'>;
 
 /**
  * Bermudian dollar.
  */
-export const BMD: DineroCurrency<number> = {
+export const BMD = {
   code: 'BMD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BMD'>;
 
 /**
  * Brunei dollar.
  */
-export const BND: DineroCurrency<number> = {
+export const BND = {
   code: 'BND',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BND'>;
 
 /**
  * Bolivian boliviano.
  */
-export const BOB: DineroCurrency<number> = {
+export const BOB = {
   code: 'BOB',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BOB'>;
 
 /**
  * Bolivian Mvdol.
  */
-export const BOV: DineroCurrency<number> = {
+export const BOV = {
   code: 'BOV',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BOV'>;
 
 /**
  * Brazilian real.
  */
-export const BRL: DineroCurrency<number> = {
+export const BRL = {
   code: 'BRL',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BRL'>;
 
 /**
  * Bahamian dollar.
  */
-export const BSD: DineroCurrency<number> = {
+export const BSD = {
   code: 'BSD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BSD'>;
 
 /**
  * Bhutanese ngultrum.
  */
-export const BTN: DineroCurrency<number> = {
+export const BTN = {
   code: 'BTN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BTN'>;
 
 /**
  * Botswana pula.
  */
-export const BWP: DineroCurrency<number> = {
+export const BWP = {
   code: 'BWP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BWP'>;
 
 /**
  * Belarusian ruble.
  */
-export const BYN: DineroCurrency<number> = {
+export const BYN = {
   code: 'BYN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BYN'>;
 
 /**
  * Belize dollar.
  */
-export const BZD: DineroCurrency<number> = {
+export const BZD = {
   code: 'BZD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'BZD'>;
 
 /**
  * Canadian dollar.
  */
-export const CAD: DineroCurrency<number> = {
+export const CAD = {
   code: 'CAD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CAD'>;
 
 /**
  * Congolese franc.
  */
-export const CDF: DineroCurrency<number> = {
+export const CDF = {
   code: 'CDF',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CDF'>;
 
 /**
  * WIR Euro.
  */
-export const CHE: DineroCurrency<number> = {
+export const CHE = {
   code: 'CHE',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CHE'>;
 
 /**
  * Swiss franc.
  */
-export const CHF: DineroCurrency<number> = {
+export const CHF = {
   code: 'CHF',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CHF'>;
 
 /**
  * WIR Franc.
  */
-export const CHW: DineroCurrency<number> = {
+export const CHW = {
   code: 'CHW',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CHW'>;
 
 /**
  * Unidad de Fomento.
  */
-export const CLF: DineroCurrency<number> = {
+export const CLF = {
   code: 'CLF',
   base: 10,
   exponent: 4,
-};
+} as const satisfies DineroCurrency<number, 'CLF'>;
 
 /**
  * Chilean peso.
  */
-export const CLP: DineroCurrency<number> = {
+export const CLP = {
   code: 'CLP',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'CLP'>;
 
 /**
  * Renminbi (Chinese) yuan.
  */
-export const CNY: DineroCurrency<number> = {
+export const CNY = {
   code: 'CNY',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CNY'>;
 
 /**
  * Colombian peso.
  */
-export const COP: DineroCurrency<number> = {
+export const COP = {
   code: 'COP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'COP'>;
 
 /**
  * Unidad de Valor Real.
  */
-export const COU: DineroCurrency<number> = {
+export const COU = {
   code: 'COU',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'COU'>;
 
 /**
  * Costa Rican colón.
  */
-export const CRC: DineroCurrency<number> = {
+export const CRC = {
   code: 'CRC',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CRC'>;
 
 /**
  * Cuban peso.
  */
-export const CUP: DineroCurrency<number> = {
+export const CUP = {
   code: 'CUP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CUP'>;
 
 /**
  * Cape Verdean escudo.
  */
-export const CVE: DineroCurrency<number> = {
+export const CVE = {
   code: 'CVE',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CVE'>;
 
 /**
  * Czech koruna.
  */
-export const CZK: DineroCurrency<number> = {
+export const CZK = {
   code: 'CZK',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'CZK'>;
 
 /**
  * Djiboutian franc.
  */
-export const DJF: DineroCurrency<number> = {
+export const DJF = {
   code: 'DJF',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'DJF'>;
 
 /**
  * Danish krone.
  */
-export const DKK: DineroCurrency<number> = {
+export const DKK = {
   code: 'DKK',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'DKK'>;
 
 /**
  * Dominican peso.
  */
-export const DOP: DineroCurrency<number> = {
+export const DOP = {
   code: 'DOP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'DOP'>;
 
 /**
  * Algerian dinar.
  */
-export const DZD: DineroCurrency<number> = {
+export const DZD = {
   code: 'DZD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'DZD'>;
 
 /**
  * Egyptian pound.
  */
-export const EGP: DineroCurrency<number> = {
+export const EGP = {
   code: 'EGP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'EGP'>;
 
 /**
  * Eritrean nakfa.
  */
-export const ERN: DineroCurrency<number> = {
+export const ERN = {
   code: 'ERN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'ERN'>;
 
 /**
  * Ethiopian birr.
  */
-export const ETB: DineroCurrency<number> = {
+export const ETB = {
   code: 'ETB',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'ETB'>;
 
 /**
  * Euro.
  */
-export const EUR: DineroCurrency<number> = {
+export const EUR = {
   code: 'EUR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'EUR'>;
 
 /**
  * Fiji dollar.
  */
-export const FJD: DineroCurrency<number> = {
+export const FJD = {
   code: 'FJD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'FJD'>;
 
 /**
  * Falkland Islands pound.
  */
-export const FKP: DineroCurrency<number> = {
+export const FKP = {
   code: 'FKP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'FKP'>;
 
 /**
  * Pound sterling.
  */
-export const GBP: DineroCurrency<number> = {
+export const GBP = {
   code: 'GBP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'GBP'>;
 
 /**
  * Georgian lari.
  */
-export const GEL: DineroCurrency<number> = {
+export const GEL = {
   code: 'GEL',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'GEL'>;
 
 /**
  * Ghanaian cedi.
  */
-export const GHS: DineroCurrency<number> = {
+export const GHS = {
   code: 'GHS',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'GHS'>;
 
 /**
  * Gibraltar pound.
  */
-export const GIP: DineroCurrency<number> = {
+export const GIP = {
   code: 'GIP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'GIP'>;
 
 /**
  * Gambian dalasi.
  */
-export const GMD: DineroCurrency<number> = {
+export const GMD = {
   code: 'GMD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'GMD'>;
 
 /**
  * Guinean franc.
  */
-export const GNF: DineroCurrency<number> = {
+export const GNF = {
   code: 'GNF',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'GNF'>;
 
 /**
  * Guatemalan quetzal.
  */
-export const GTQ: DineroCurrency<number> = {
+export const GTQ = {
   code: 'GTQ',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'GTQ'>;
 
 /**
  * Guyanese dollar.
  */
-export const GYD: DineroCurrency<number> = {
+export const GYD = {
   code: 'GYD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'GYD'>;
 
 /**
  * Hong Kong dollar.
  */
-export const HKD: DineroCurrency<number> = {
+export const HKD = {
   code: 'HKD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'HKD'>;
 
 /**
  * Honduran lempira.
  */
-export const HNL: DineroCurrency<number> = {
+export const HNL = {
   code: 'HNL',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'HNL'>;
 
 /**
  * Haitian gourde.
  */
-export const HTG: DineroCurrency<number> = {
+export const HTG = {
   code: 'HTG',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'HTG'>;
 
 /**
  * Hungarian forint.
  */
-export const HUF: DineroCurrency<number> = {
+export const HUF = {
   code: 'HUF',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'HUF'>;
 
 /**
  * Indonesian rupiah.
  */
-export const IDR: DineroCurrency<number> = {
+export const IDR = {
   code: 'IDR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'IDR'>;
 
 /**
  * Israeli new shekel.
  */
-export const ILS: DineroCurrency<number> = {
+export const ILS = {
   code: 'ILS',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'ILS'>;
 
 /**
  * Indian rupee.
  */
-export const INR: DineroCurrency<number> = {
+export const INR = {
   code: 'INR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'INR'>;
 
 /**
  * Iraqi dinar.
  */
-export const IQD: DineroCurrency<number> = {
+export const IQD = {
   code: 'IQD',
   base: 10,
   exponent: 3,
-};
+} as const satisfies DineroCurrency<number, 'IQD'>;
 
 /**
  * Iranian rial.
  */
-export const IRR: DineroCurrency<number> = {
+export const IRR = {
   code: 'IRR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'IRR'>;
 
 /**
  * Icelandic króna.
  */
-export const ISK: DineroCurrency<number> = {
+export const ISK = {
   code: 'ISK',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'ISK'>;
 
 /**
  * Jamaican dollar.
  */
-export const JMD: DineroCurrency<number> = {
+export const JMD = {
   code: 'JMD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'JMD'>;
 
 /**
  * Jordanian dinar.
  */
-export const JOD: DineroCurrency<number> = {
+export const JOD = {
   code: 'JOD',
   base: 10,
   exponent: 3,
-};
+} as const satisfies DineroCurrency<number, 'JOD'>;
 
 /**
  * Japanese yen.
  */
-export const JPY: DineroCurrency<number> = {
+export const JPY = {
   code: 'JPY',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'JPY'>;
 
 /**
  * Kenyan shilling.
  */
-export const KES: DineroCurrency<number> = {
+export const KES = {
   code: 'KES',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'KES'>;
 
 /**
  * Kyrgyzstani som.
  */
-export const KGS: DineroCurrency<number> = {
+export const KGS = {
   code: 'KGS',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'KGS'>;
 
 /**
  * Cambodian riel.
  */
-export const KHR: DineroCurrency<number> = {
+export const KHR = {
   code: 'KHR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'KHR'>;
 
 /**
  * Comoro franc.
  */
-export const KMF: DineroCurrency<number> = {
+export const KMF = {
   code: 'KMF',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'KMF'>;
 
 /**
  * North Korean won.
  */
-export const KPW: DineroCurrency<number> = {
+export const KPW = {
   code: 'KPW',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'KPW'>;
 
 /**
  * South Korean won.
  */
-export const KRW: DineroCurrency<number> = {
+export const KRW = {
   code: 'KRW',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'KRW'>;
 
 /**
  * Kuwaiti dinar.
  */
-export const KWD: DineroCurrency<number> = {
+export const KWD = {
   code: 'KWD',
   base: 10,
   exponent: 3,
-};
+} as const satisfies DineroCurrency<number, 'KWD'>;
 
 /**
  * Cayman Islands dollar.
  */
-export const KYD: DineroCurrency<number> = {
+export const KYD = {
   code: 'KYD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'KYD'>;
 
 /**
  * Kazakhstani tenge.
  */
-export const KZT: DineroCurrency<number> = {
+export const KZT = {
   code: 'KZT',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'KZT'>;
 
 /**
  * Lao kip.
  */
-export const LAK: DineroCurrency<number> = {
+export const LAK = {
   code: 'LAK',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'LAK'>;
 
 /**
  * Lebanese pound.
  */
-export const LBP: DineroCurrency<number> = {
+export const LBP = {
   code: 'LBP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'LBP'>;
 
 /**
  * Sri Lankan rupee.
  */
-export const LKR: DineroCurrency<number> = {
+export const LKR = {
   code: 'LKR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'LKR'>;
 
 /**
  * Liberian dollar.
  */
-export const LRD: DineroCurrency<number> = {
+export const LRD = {
   code: 'LRD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'LRD'>;
 
 /**
  * Lesotho loti.
  */
-export const LSL: DineroCurrency<number> = {
+export const LSL = {
   code: 'LSL',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'LSL'>;
 
 /**
  * Libyan dinar.
  */
-export const LYD: DineroCurrency<number> = {
+export const LYD = {
   code: 'LYD',
   base: 10,
   exponent: 3,
-};
+} as const satisfies DineroCurrency<number, 'LYD'>;
 
 /**
  * Moroccan dirham.
  */
-export const MAD: DineroCurrency<number> = {
+export const MAD = {
   code: 'MAD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MAD'>;
 
 /**
  * Moldovan leu.
  */
-export const MDL: DineroCurrency<number> = {
+export const MDL = {
   code: 'MDL',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MDL'>;
 
 /**
  * Malagasy ariary.
  */
-export const MGA: DineroCurrency<number> = {
+export const MGA = {
   code: 'MGA',
   base: 5,
   exponent: 1,
-};
+} as const satisfies DineroCurrency<number, 'MGA'>;
 
 /**
  * Macedonian denar.
  */
-export const MKD: DineroCurrency<number> = {
+export const MKD = {
   code: 'MKD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MKD'>;
 
 /**
  * Myanmar kyat.
  */
-export const MMK: DineroCurrency<number> = {
+export const MMK = {
   code: 'MMK',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MMK'>;
 
 /**
  * Mongolian tögrög.
  */
-export const MNT: DineroCurrency<number> = {
+export const MNT = {
   code: 'MNT',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MNT'>;
 
 /**
  * Macanese pataca.
  */
-export const MOP: DineroCurrency<number> = {
+export const MOP = {
   code: 'MOP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MOP'>;
 
 /**
  * Mauritanian ouguiya.
  */
-export const MRU: DineroCurrency<number> = {
+export const MRU = {
   code: 'MRU',
   base: 5,
   exponent: 1,
-};
+} as const satisfies DineroCurrency<number, 'MRU'>;
 
 /**
  * Mauritian rupee.
  */
-export const MUR: DineroCurrency<number> = {
+export const MUR = {
   code: 'MUR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MUR'>;
 
 /**
  * Maldivian rufiyaa.
  */
-export const MVR: DineroCurrency<number> = {
+export const MVR = {
   code: 'MVR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MVR'>;
 
 /**
  * Malawian kwacha.
  */
-export const MWK: DineroCurrency<number> = {
+export const MWK = {
   code: 'MWK',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MWK'>;
 
 /**
  * Mexican peso.
  */
-export const MXN: DineroCurrency<number> = {
+export const MXN = {
   code: 'MXN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MXN'>;
 
 /**
  * Mexican Unidad de Inversion.
  */
-export const MXV: DineroCurrency<number> = {
+export const MXV = {
   code: 'MXV',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MXV'>;
 
 /**
  * Malaysian ringgit.
  */
-export const MYR: DineroCurrency<number> = {
+export const MYR = {
   code: 'MYR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MYR'>;
 
 /**
  * Mozambican metical.
  */
-export const MZN: DineroCurrency<number> = {
+export const MZN = {
   code: 'MZN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'MZN'>;
 
 /**
  * Namibian dollar.
  */
-export const NAD: DineroCurrency<number> = {
+export const NAD = {
   code: 'NAD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'NAD'>;
 
 /**
  * Nigerian naira.
  */
-export const NGN: DineroCurrency<number> = {
+export const NGN = {
   code: 'NGN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'NGN'>;
 
 /**
  * Nicaraguan córdoba.
  */
-export const NIO: DineroCurrency<number> = {
+export const NIO = {
   code: 'NIO',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'NIO'>;
 
 /**
  * Norwegian krone.
  */
-export const NOK: DineroCurrency<number> = {
+export const NOK = {
   code: 'NOK',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'NOK'>;
 
 /**
  * Nepalese rupee.
  */
-export const NPR: DineroCurrency<number> = {
+export const NPR = {
   code: 'NPR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'NPR'>;
 
 /**
  * New Zealand dollar.
  */
-export const NZD: DineroCurrency<number> = {
+export const NZD = {
   code: 'NZD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'NZD'>;
 
 /**
  * Omani rial.
  */
-export const OMR: DineroCurrency<number> = {
+export const OMR = {
   code: 'OMR',
   base: 10,
   exponent: 3,
-};
+} as const satisfies DineroCurrency<number, 'OMR'>;
 
 /**
  * Panamanian balboa.
  */
-export const PAB: DineroCurrency<number> = {
+export const PAB = {
   code: 'PAB',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'PAB'>;
 
 /**
  * Peruvian sol.
  */
-export const PEN: DineroCurrency<number> = {
+export const PEN = {
   code: 'PEN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'PEN'>;
 
 /**
  * Papua New Guinean kina.
  */
-export const PGK: DineroCurrency<number> = {
+export const PGK = {
   code: 'PGK',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'PGK'>;
 
 /**
  * Philippine peso.
  */
-export const PHP: DineroCurrency<number> = {
+export const PHP = {
   code: 'PHP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'PHP'>;
 
 /**
  * Pakistani rupee.
  */
-export const PKR: DineroCurrency<number> = {
+export const PKR = {
   code: 'PKR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'PKR'>;
 
 /**
  * Polish złoty.
  */
-export const PLN: DineroCurrency<number> = {
+export const PLN = {
   code: 'PLN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'PLN'>;
 
 /**
  * Paraguayan guaraní.
  */
-export const PYG: DineroCurrency<number> = {
+export const PYG = {
   code: 'PYG',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'PYG'>;
 
 /**
  * Qatari riyal.
  */
-export const QAR: DineroCurrency<number> = {
+export const QAR = {
   code: 'QAR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'QAR'>;
 
 /**
  * Romanian leu.
  */
-export const RON: DineroCurrency<number> = {
+export const RON = {
   code: 'RON',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'RON'>;
 
 /**
  * Serbian dinar.
  */
-export const RSD: DineroCurrency<number> = {
+export const RSD = {
   code: 'RSD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'RSD'>;
 
 /**
  * Russian ruble.
  */
-export const RUB: DineroCurrency<number> = {
+export const RUB = {
   code: 'RUB',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'RUB'>;
 
 /**
  * Rwandan franc.
  */
-export const RWF: DineroCurrency<number> = {
+export const RWF = {
   code: 'RWF',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'RWF'>;
 
 /**
  * Saudi riyal.
  */
-export const SAR: DineroCurrency<number> = {
+export const SAR = {
   code: 'SAR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SAR'>;
 
 /**
  * Solomon Islands dollar.
  */
-export const SBD: DineroCurrency<number> = {
+export const SBD = {
   code: 'SBD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SBD'>;
 
 /**
  * Seychelles rupee.
  */
-export const SCR: DineroCurrency<number> = {
+export const SCR = {
   code: 'SCR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SCR'>;
 
 /**
  * Sudanese pound.
  */
-export const SDG: DineroCurrency<number> = {
+export const SDG = {
   code: 'SDG',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SDG'>;
 
 /**
  * Swedish krona.
  */
-export const SEK: DineroCurrency<number> = {
+export const SEK = {
   code: 'SEK',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SEK'>;
 
 /**
  * Singapore dollar.
  */
-export const SGD: DineroCurrency<number> = {
+export const SGD = {
   code: 'SGD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SGD'>;
 
 /**
  * Saint Helena pound.
  */
-export const SHP: DineroCurrency<number> = {
+export const SHP = {
   code: 'SHP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SHP'>;
 
 /**
  * Sierra Leonean leone.
  */
-export const SLE: DineroCurrency<number> = {
+export const SLE = {
   code: 'SLE',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SLE'>;
 
 /**
  * Somali shilling.
  */
-export const SOS: DineroCurrency<number> = {
+export const SOS = {
   code: 'SOS',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SOS'>;
 
 /**
  * Surinamese dollar.
  */
-export const SRD: DineroCurrency<number> = {
+export const SRD = {
   code: 'SRD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SRD'>;
 
 /**
  * South Sudanese pound.
  */
-export const SSP: DineroCurrency<number> = {
+export const SSP = {
   code: 'SSP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SSP'>;
 
 /**
  * São Tomé and Príncipe dobra.
  */
-export const STN: DineroCurrency<number> = {
+export const STN = {
   code: 'STN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'STN'>;
 
 /**
  * Salvadoran colón.
  */
-export const SVC: DineroCurrency<number> = {
+export const SVC = {
   code: 'SVC',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SVC'>;
 
 /**
  * Syrian pound.
  */
-export const SYP: DineroCurrency<number> = {
+export const SYP = {
   code: 'SYP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SYP'>;
 
 /**
  * Swazi lilangeni.
  */
-export const SZL: DineroCurrency<number> = {
+export const SZL = {
   code: 'SZL',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'SZL'>;
 
 /**
  * Thai baht.
  */
-export const THB: DineroCurrency<number> = {
+export const THB = {
   code: 'THB',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'THB'>;
 
 /**
  * Tajikistani somoni.
  */
-export const TJS: DineroCurrency<number> = {
+export const TJS = {
   code: 'TJS',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'TJS'>;
 
 /**
  * Turkmenistan manat.
  */
-export const TMT: DineroCurrency<number> = {
+export const TMT = {
   code: 'TMT',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'TMT'>;
 
 /**
  * Tunisian dinar.
  */
-export const TND: DineroCurrency<number> = {
+export const TND = {
   code: 'TND',
   base: 10,
   exponent: 3,
-};
+} as const satisfies DineroCurrency<number, 'TND'>;
 
 /**
  * Tongan paʻanga.
  */
-export const TOP: DineroCurrency<number> = {
+export const TOP = {
   code: 'TOP',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'TOP'>;
 
 /**
  * Turkish lira.
  */
-export const TRY: DineroCurrency<number> = {
+export const TRY = {
   code: 'TRY',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'TRY'>;
 
 /**
  * Trinidad and Tobago dollar.
  */
-export const TTD: DineroCurrency<number> = {
+export const TTD = {
   code: 'TTD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'TTD'>;
 
 /**
  * New Taiwan dollar.
  */
-export const TWD: DineroCurrency<number> = {
+export const TWD = {
   code: 'TWD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'TWD'>;
 
 /**
  * Tanzanian shilling.
  */
-export const TZS: DineroCurrency<number> = {
+export const TZS = {
   code: 'TZS',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'TZS'>;
 
 /**
  * Ukrainian hryvnia.
  */
-export const UAH: DineroCurrency<number> = {
+export const UAH = {
   code: 'UAH',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'UAH'>;
 
 /**
  * Ugandan shilling.
  */
-export const UGX: DineroCurrency<number> = {
+export const UGX = {
   code: 'UGX',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'UGX'>;
 
 /**
  * United States dollar.
  */
-export const USD: DineroCurrency<number> = {
+export const USD = {
   code: 'USD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'USD'>;
 
 /**
  * United States dollar (next day).
  */
-export const USN: DineroCurrency<number> = {
+export const USN = {
   code: 'USN',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'USN'>;
 
 /**
  * Uruguay Peso en Unidades Indexadas.
  */
-export const UYI: DineroCurrency<number> = {
+export const UYI = {
   code: 'UYI',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'UYI'>;
 
 /**
  * Uruguayan peso.
  */
-export const UYU: DineroCurrency<number> = {
+export const UYU = {
   code: 'UYU',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'UYU'>;
 
 /**
  * Unidad previsional.
  */
-export const UYW: DineroCurrency<number> = {
+export const UYW = {
   code: 'UYW',
   base: 10,
   exponent: 4,
-};
+} as const satisfies DineroCurrency<number, 'UYW'>;
 
 /**
  * Uzbekistani soʻm.
  */
-export const UZS: DineroCurrency<number> = {
+export const UZS = {
   code: 'UZS',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'UZS'>;
 
 /**
  * Venezuelan digital bolívar.
  */
-export const VED: DineroCurrency<number> = {
+export const VED = {
   code: 'VED',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'VED'>;
 
 /**
  * Venezuelan bolívar.
  */
-export const VES: DineroCurrency<number> = {
+export const VES = {
   code: 'VES',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'VES'>;
 
 /**
  * Vietnamese đồng.
  */
-export const VND: DineroCurrency<number> = {
+export const VND = {
   code: 'VND',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'VND'>;
 
 /**
  * Vanuatu vatu.
  */
-export const VUV: DineroCurrency<number> = {
+export const VUV = {
   code: 'VUV',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'VUV'>;
 
 /**
  * Samoan tālā.
  */
-export const WST: DineroCurrency<number> = {
+export const WST = {
   code: 'WST',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'WST'>;
 
 /**
  * Arab Accounting Dinar.
  */
-export const XAD: DineroCurrency<number> = {
+export const XAD = {
   code: 'XAD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'XAD'>;
 
 /**
  * Central African CFA franc.
  */
-export const XAF: DineroCurrency<number> = {
+export const XAF = {
   code: 'XAF',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'XAF'>;
 
 /**
  * East Caribbean dollar.
  */
-export const XCD: DineroCurrency<number> = {
+export const XCD = {
   code: 'XCD',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'XCD'>;
 
 /**
  * Caribbean guilder.
  */
-export const XCG: DineroCurrency<number> = {
+export const XCG = {
   code: 'XCG',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'XCG'>;
 
 /**
  * West African CFA franc.
  */
-export const XOF: DineroCurrency<number> = {
+export const XOF = {
   code: 'XOF',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'XOF'>;
 
 /**
  * CFP franc.
  */
-export const XPF: DineroCurrency<number> = {
+export const XPF = {
   code: 'XPF',
   base: 10,
   exponent: 0,
-};
+} as const satisfies DineroCurrency<number, 'XPF'>;
 
 /**
  * Yemeni rial.
  */
-export const YER: DineroCurrency<number> = {
+export const YER = {
   code: 'YER',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'YER'>;
 
 /**
  * South African rand.
  */
-export const ZAR: DineroCurrency<number> = {
+export const ZAR = {
   code: 'ZAR',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'ZAR'>;
 
 /**
  * Zambian kwacha.
  */
-export const ZMW: DineroCurrency<number> = {
+export const ZMW = {
   code: 'ZMW',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'ZMW'>;
 
 /**
  * Zimbabwe Gold.
  */
-export const ZWG: DineroCurrency<number> = {
+export const ZWG = {
   code: 'ZWG',
   base: 10,
   exponent: 2,
-};
+} as const satisfies DineroCurrency<number, 'ZWG'>;

--- a/packages/dinero.js/src/currencies/types/DineroCurrency.ts
+++ b/packages/dinero.js/src/currencies/types/DineroCurrency.ts
@@ -1,8 +1,8 @@
-export type DineroCurrency<TAmount> = {
+export type DineroCurrency<TAmount, TCurrency extends string = string> = {
   /**
    * The unique code of the currency.
    */
-  readonly code: string;
+  readonly code: TCurrency;
   /**
    * The base, or radix of the currency.
    */

--- a/test/utils/castToBigintCurrency.ts
+++ b/test/utils/castToBigintCurrency.ts
@@ -1,8 +1,8 @@
 import type { DineroCurrency } from 'dinero.js';
 
-export function castToBigintCurrency(
-  currency: DineroCurrency<number>
-): DineroCurrency<bigint> {
+export function castToBigintCurrency<TCurrency extends string>(
+  currency: DineroCurrency<number, TCurrency>
+): DineroCurrency<bigint, TCurrency> {
   return {
     ...currency,
     base: Array.isArray(currency.base)

--- a/test/utils/castToBigjsCurrency.ts
+++ b/test/utils/castToBigjsCurrency.ts
@@ -2,9 +2,9 @@ import Big from 'big.js';
 
 import type { DineroCurrency } from 'dinero.js';
 
-export function castToBigjsCurrency(
-  currency: DineroCurrency<number>
-): DineroCurrency<Big> {
+export function castToBigjsCurrency<TCurrency extends string>(
+  currency: DineroCurrency<number, TCurrency>
+): DineroCurrency<Big, TCurrency> {
   return {
     ...currency,
     base: Array.isArray(currency.base)

--- a/test/utils/createBigintDinero.ts
+++ b/test/utils/createBigintDinero.ts
@@ -1,6 +1,8 @@
 import { dinero } from 'dinero.js/bigint';
 import type { DineroOptions } from 'dinero.js';
 
-export function createBigintDinero(options: DineroOptions<bigint>) {
+export function createBigintDinero<TCurrency extends string>(
+  options: DineroOptions<bigint, TCurrency>
+) {
   return dinero(options);
 }

--- a/test/utils/createBigjsDinero.ts
+++ b/test/utils/createBigjsDinero.ts
@@ -18,6 +18,8 @@ const dinero = createDinero({
   },
 });
 
-export function createBigjsDinero(options: DineroOptions<Big>) {
+export function createBigjsDinero<TCurrency extends string>(
+  options: DineroOptions<Big, TCurrency>
+) {
   return dinero(options);
 }

--- a/test/utils/createNumberDinero.ts
+++ b/test/utils/createNumberDinero.ts
@@ -1,6 +1,8 @@
 import { dinero } from 'dinero.js';
 import type { DineroOptions } from 'dinero.js';
 
-export function createNumberDinero(options: DineroOptions<number>) {
+export function createNumberDinero<TCurrency extends string>(
+  options: DineroOptions<number, TCurrency>
+) {
   return dinero(options);
 }


### PR DESCRIPTION
## Summary

- Add a `TCurrency extends string = string` generic type parameter across the entire type system, enabling TypeScript to catch currency mismatches (e.g., `add(usdDinero, eurDinero)`) at compile time
- Use `NoInfer<TCurrency>` on second operands of binary operations and variadic tuple rest elements for array operations, preventing TypeScript from widening to a union type
- Update all 166 ISO 4217 currency constants to use `as const satisfies` for literal type inference (e.g., `'USD'` instead of `string`)
- Add a dedicated `currency-safety.typetest.ts` file that validates type enforcement via `@ts-expect-error` directives
- Add `@ts-expect-error` annotations to 48 existing test locations that intentionally mix currencies for runtime error testing
- Add a new "Currency type safety" documentation guide and update all API reference pages with `TCurrency` type signatures

## Highlights

The feature is fully opt-in and backward compatible. The `= string` default means existing code works without changes. Type safety activates automatically when using the built-in ISO 4217 currencies or custom currencies defined with `as const satisfies`.

Inspired by https://github.com/dinerojs/dinero.js/discussions/407.