### PR TITLE
docs(examples): add Fathom analytics to demo pages

### DIFF
--- a/examples/cart-react/index.html
+++ b/examples/cart-react/index.html
@@ -11,6 +11,11 @@
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap"
       rel="stylesheet"
     />
+    <script
+      src="https://cdn.usefathom.com/script.js"
+      data-site="PSUFDDGC"
+      defer
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/cart-vue/index.html
+++ b/examples/cart-vue/index.html
@@ -11,6 +11,11 @@
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap"
       rel="stylesheet"
     />
+    <script
+      src="https://cdn.usefathom.com/script.js"
+      data-site="PSUFDDGC"
+      defer
+    ></script>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/expense-splitter/index.html
+++ b/examples/expense-splitter/index.html
@@ -12,6 +12,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0c0d0f" />
     <title>Dinero.js &amp; React | Expense Splitter</title>
+    <script
+      src="https://cdn.usefathom.com/script.js"
+      data-site="PSUFDDGC"
+      defer
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/invoice-builder/index.html
+++ b/examples/invoice-builder/index.html
@@ -12,6 +12,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0c0d0f" />
     <title>Dinero.js &amp; React | Invoice Builder</title>
+    <script
+      src="https://cdn.usefathom.com/script.js"
+      data-site="PSUFDDGC"
+      defer
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/portfolio-tracker/index.html
+++ b/examples/portfolio-tracker/index.html
@@ -11,6 +11,11 @@
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap"
       rel="stylesheet"
     />
+    <script
+      src="https://cdn.usefathom.com/script.js"
+      data-site="PSUFDDGC"
+      defer
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/pricing-react/index.html
+++ b/examples/pricing-react/index.html
@@ -11,6 +11,11 @@
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap"
       rel="stylesheet"
     />
+    <script
+      src="https://cdn.usefathom.com/script.js"
+      data-site="PSUFDDGC"
+      defer
+    ></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- Add Fathom analytics script (`PSUFDDGC`) to all 6 example demo `index.html` files
- Demo pages are standalone Vite apps served under `/examples/*` and render outside of VitePress, so they were missing the analytics tracking present on the rest of the docs site