### PR TITLE
fix(core): add "type": "module" to package.json

### DIFF
--- a/packages/dinero.js/package.json
+++ b/packages/dinero.js/package.json
@@ -25,6 +25,7 @@
     "type": "git",
     "url": "https://github.com/dinerojs/dinero.js.git"
   },
+  "type": "module",
   "license": "MIT",
   "author": {
     "name": "Sarah Dayan",


### PR DESCRIPTION
## Summary

- Add `"type": "module"` to `packages/dinero.js/package.json`
- Node.js treats `.js` files as CommonJS by default; without this field, the ESM output in `dist/esm/` fails to load in Node.js environments

Fixes #843