### PR TITLE
fix: reject non-decimal scalar bases in toDecimal

### DIFF
--- a/packages/dinero.js/src/api/__tests__/toDecimal.test.ts
+++ b/packages/dinero.js/src/api/__tests__/toDecimal.test.ts
@@ -77,6 +77,18 @@ describe('toDecimal', () => {
           `[Error: [Dinero.js] Currency is not decimal.]`
         );
       });
+      it('throws when passing a scalar base which is a multiple of 10', () => {
+        const d = dinero({
+          amount: 25,
+          currency: { code: 'ABC', exponent: 1, base: 20 },
+        });
+
+        expect(() => {
+          toDecimal(d);
+        }).toThrowErrorMatchingInlineSnapshot(
+          `[Error: [Dinero.js] Currency is not decimal.]`
+        );
+      });
       it('throws when passing a Dinero object using a multi-base currency which compiles to a multiple of 10', () => {
         const d = dinero({
           amount: 13,
@@ -158,6 +170,18 @@ describe('toDecimal', () => {
     describe('non-decimal currencies', () => {
       it('throws when passing a Dinero object using a non-decimal currency', () => {
         const d = dinero({ amount: 13n, currency: bigintMGA });
+
+        expect(() => {
+          toDecimal(d);
+        }).toThrowErrorMatchingInlineSnapshot(
+          `[Error: [Dinero.js] Currency is not decimal.]`
+        );
+      });
+      it('throws when passing a scalar base which is a multiple of 10', () => {
+        const d = dinero({
+          amount: 25n,
+          currency: { code: 'ABC', exponent: 1n, base: 20n },
+        });
 
         expect(() => {
           toDecimal(d);
@@ -253,6 +277,22 @@ describe('toDecimal', () => {
     describe('non-decimal currencies', () => {
       it('throws when passing a Dinero object using a non-decimal currency', () => {
         const d = dinero({ amount: new Big(13), currency: bigjsMGA });
+
+        expect(() => {
+          toDecimal(d);
+        }).toThrowErrorMatchingInlineSnapshot(
+          `[Error: [Dinero.js] Currency is not decimal.]`
+        );
+      });
+      it('throws when passing a scalar base which is a multiple of 10', () => {
+        const d = dinero({
+          amount: new Big(25),
+          currency: {
+            code: 'ABC',
+            exponent: new Big(1),
+            base: new Big(20),
+          },
+        });
 
         expect(() => {
           toDecimal(d);

--- a/packages/dinero.js/src/core/api/toDecimal.ts
+++ b/packages/dinero.js/src/core/api/toDecimal.ts
@@ -36,7 +36,7 @@ export function toDecimal<TAmount, TOutput>(
     const ten = new Array(10).fill(null).reduce(calculator.increment, zero);
 
     const isMultiBase = isArray(currency.base);
-    const isBaseTen = equalFn(calculator.modulo(base, ten), zero);
+    const isBaseTen = equalFn(base, ten);
     const isDecimal = !isMultiBase && isBaseTen;
 
     assert(isDecimal, NON_DECIMAL_CURRENCY_MESSAGE);


### PR DESCRIPTION
## What

- require a single-base currency radix to equal 10 before `toDecimal()` formats it
- add regression coverage for number, bigint, and Big.js calculators

Fixes #889.

## Why

The previous predicate checked whether the scalar base was divisible by 10. That accepted non-decimal radices such as 20, 60, and 240 and returned plausible but numerically incorrect decimal strings. For example, 25 units in base 20 were rendered as `1.5`, although the exact value is 1.25.

Comparing the radix directly with 10 matches the documented requirement that `toDecimal()` supports single-base decimal currencies. Multi-base currencies remain rejected.

## Validation

- mutation check: all three new regression tests fail with the previous predicate
- `npm test -- --run`: 74 files, 851 tests passed
- `npm run test:types`: passed
- `npm run lint`: no warnings or errors
- Prettier check on both changed files: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved decimal currency validation to correctly reject currencies whose base is not a power of ten.
  - `toDecimal` now consistently reports that the currency is not decimal for unsupported bases, including across number, bigint, and Big.js currency representations.

- **Tests**
  - Added coverage for invalid decimal conversions using multiple currency value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->